### PR TITLE
Scaffold Aegis: Exchange addon skeleton + CLAUDE.md

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,0 +1,12 @@
+## Interface: 11200
+## Title: Aegis: Exchange
+## Notes: Clean auction house helper for Turtle WoW
+## SavedVariables: AegisExchangeDB
+## SavedVariablesPerCharacter: AegisExchangeCharDB
+
+core\init.lua
+core\util.lua
+core\db.lua
+core\scan.lua
+ui\frame.lua
+ui\tooltip.lua

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,146 @@
+# CLAUDE.md — Aegis: Exchange
+
+A World of Warcraft addon (folder + `.toc` name: **`Aegis_Exchange`**) — a clean
+auction house helper for **Turtle WoW 1.18.1**, which runs the **ORIGINAL WoW
+1.12 (vanilla) client on Lua 5.0**.
+
+> This is **NOT** WoW Classic and **NOT** retail. Do **not** use any API newer
+> than patch **1.12**. When in doubt, assume the API does not exist.
+
+---
+
+## HARD RULES — never violate these
+
+These are not style preferences. Breaking any of them produces a runtime error
+or silent breakage on the 1.12 / Lua 5.0 client.
+
+### Language (Lua 5.0)
+
+1. **Lua 5.0 only.** **NO** `string.match`, **NO** `string.gmatch`, **NO**
+   `:match()`. Use **`string.find`** (with captures) and **`string.gfind`**.
+   - `string.gfind` is the 5.0 name for what later Lua calls `string.gmatch`.
+2. **NO `#` length operator.** Use **`table.getn(t)`**. **NO `table.setn`.**
+3. **NO `%` modulo operator.** Use **`math.mod(a, b)`**.
+   - Lua 5.0 also has no integer division — combine `math.floor` with
+     `math.mod`.
+4. **Varargs use the `arg` table and `arg.n`** — not `...` expansion helpers
+   from later versions. (`select()` does not exist.)
+5. String library note: `string.gsub`, `string.find`, `string.gfind`,
+   `string.format`, `string.sub`, `string.lower`/`upper` are fine. The banned
+   ones are strictly the `match`/`gmatch` family.
+
+### Events
+
+6. **Event handlers read the GLOBALS `event`, `arg1`, `arg2`, …** — **NOT**
+   `function(self, event, ...)`. On this client the OnEvent script receives no
+   arguments; the client sets `this`, `event`, and `arg1..argN` as globals.
+   - Central dispatch lives in `core/init.lua`. Register with
+     `AegisExchange.RegisterEvent(evt, fn)`; the dispatcher reads the globals
+     and forwards them.
+
+### Hooking
+
+7. **NO `hooksecurefunc` and NO secure hooks.** Hook by **saving the original
+   function and replacing it**, then call the saved original from your
+   replacement. (Secure-hook infrastructure does not exist in 1.12.)
+   See `ui/tooltip.lua` for the canonical pattern.
+
+### Auction House API (1.12)
+
+8. **`GetAuctionItemInfo("list", i)`** returns **ONLY** these values, in order:
+   ```
+   name, texture, count, quality, canUse, level,
+   minBid, minIncrement, buyoutPrice, bidAmount, highBidder, owner
+   ```
+   Nothing else. **`owner` may be `nil`** until the name resolves — re-read the
+   page or handle nil gracefully.
+9. **`QueryAuctionItems` takes 9 args:**
+   ```
+   QueryAuctionItems(name, minLevel, maxLevel, invTypeIndex,
+                     classIndex, subclassIndex, page, isUsable, qualityIndex)
+   ```
+   - **`page` is 0-indexed.**
+   - **There is NO working `getAll` on 1.12.** Do not attempt a bulk pull.
+10. **Throttle every query.** Poll **`CanSendAuctionQuery()`** before **every**
+    query. Leave **~4 seconds between pages**. Wait for the
+    **`AUCTION_ITEM_LIST_UPDATE`** event before reading a page.
+11. **Page size is 50.**
+
+### SavedVariables
+
+12. **SavedVariables are `nil` until `ADDON_LOADED` fires for
+    `"Aegis_Exchange"`.** Do all DB setup from the ADDON_LOADED path (queue via
+    `AegisExchange.OnLoad(fn)`), never at file scope.
+    - `AegisExchangeDB` — account-wide (declared `## SavedVariables`).
+    - `AegisExchangeCharDB` — per-character (`## SavedVariablesPerCharacter`).
+
+### Frames & globals
+
+13. Use **`getglobal()` / `setglobal()`** for dynamic frame names (e.g.
+    building `"AuctionFrameTab" .. n`).
+14. Build frames with **`CreateFrame`** using **vanilla templates only**, e.g.
+    `UIPanelButtonTemplate`, `FauxScrollFrameTemplate`, `GameTooltipTemplate`,
+    `AuctionFrameTab`.
+
+---
+
+## Turtle WoW specifics
+
+Turtle exposes a global **`TURTLE_WOW_VERSION`** — use it to detect Turtle
+(see `AegisExchange.isTurtle`).
+
+- **Cross-faction AH.** Turtle's auction house is a **single shared economy**.
+  Do **not** split the price DB by faction.
+- **Auction durations are ×3 vanilla** — max **72h**.
+- **Deposit is inflated** in what the client shows. Apply a **~0.6 factor** as
+  an approximation and **label it "approx"** in the UI. Never present it as
+  exact.
+- **120-auction account cap.**
+- **5% faction consignment cut** on sales.
+
+---
+
+## Project layout
+
+```
+Aegis_Exchange/
+  Aegis_Exchange.toc     -- Interface 11200; declares SavedVariables + load order
+  core/init.lua          -- namespace (AegisExchange) + event dispatcher + OnLoad queue
+  core/util.lua          -- Lua 5.0 safe helpers (money fmt/parse, split, table utils)
+  core/db.lua            -- SavedVariables price DB scaffolding
+  core/scan.lua          -- auction scanner module (stub)
+  ui/frame.lua           -- Aegis tab attach on AuctionFrame (stub)
+  ui/tooltip.lua         -- GameTooltip hook (stub)
+  CLAUDE.md              -- this file
+```
+
+Load order is fixed by the `.toc`: `init` → `util` → `db` → `scan` → `frame` →
+`tooltip`. `init.lua` must load first (it creates the namespace and dispatcher).
+
+The repository root **is** the addon folder: clone/copy it into
+`Interface/AddOns/Aegis_Exchange` so the folder name matches the `.toc`.
+
+---
+
+## Reference addons
+
+Read their patterns for how vanilla AH scanning, throttling, and tooltip hooks
+are done in practice — **imitate the approach, do not copy code blindly**:
+
+- **aux-addon-vanilla** — https://github.com/shirsig/aux-addon-vanilla
+- **AuctionatorVanilla** — https://github.com/nimeral/AuctionatorVanilla
+- **LilSparkysWorkshop-vanilla** — https://github.com/laytya/LilSparkysWorkshop-vanilla
+
+---
+
+## Quick self-check before committing Lua
+
+- [ ] No `string.match` / `string.gmatch` / `:match()` — used `string.find` /
+      `string.gfind`.
+- [ ] No `#` — used `table.getn`. No `table.setn`.
+- [ ] No `%` operator — used `math.mod`.
+- [ ] Event handlers read `event` / `arg1…` globals (not `self, event, ...`).
+- [ ] No `hooksecurefunc` / secure hooks — saved original + replaced.
+- [ ] AH reads match the 12-value `GetAuctionItemInfo` and 9-arg
+      `QueryAuctionItems` signatures; queries gated on `CanSendAuctionQuery()`.
+- [ ] DB touched only after `ADDON_LOADED` for `"Aegis_Exchange"`.

--- a/core/db.lua
+++ b/core/db.lua
@@ -1,0 +1,95 @@
+-- Aegis: Exchange
+-- core/db.lua
+--
+-- SavedVariables scaffolding for the price database.
+--
+-- Declared in Aegis_Exchange.toc:
+--   AegisExchangeDB      -- account-wide. Turtle's AH is CROSS-FACTION (one
+--                           shared economy), so prices are NOT split by
+--                           faction here.
+--   AegisExchangeCharDB  -- per-character. UI state, last scan time, etc.
+--
+-- IMPORTANT: both globals are nil until ADDON_LOADED fires for
+-- "Aegis_Exchange". All access goes through db.Init(), which is queued on the
+-- init.lua OnLoad list and therefore runs at exactly the right moment.
+
+local A = AegisExchange
+A.db = {}
+local db = A.db
+
+-- Bump when the on-disk shape changes so we can migrate old data.
+local DB_VERSION = 1
+
+-- Default shape of the account-wide DB.
+local function DefaultAccountDB()
+    return {
+        version = DB_VERSION,
+        -- itemId -> { min = copper, market = copper, seen = time, count = n }
+        prices = {},
+        -- itemName -> itemId, to resolve names from tooltips / item links.
+        nameToId = {},
+    }
+end
+
+-- Default shape of the per-character DB.
+local function DefaultCharDB()
+    return {
+        version  = DB_VERSION,
+        ui       = {},    -- window position, open tab, column widths, ...
+        lastScan = nil,   -- server time of the last completed full scan
+    }
+end
+
+-- Fill in any missing default keys on `target` without clobbering existing
+-- values. Copies one level of nested default tables.
+local function ApplyDefaults(target, defaults)
+    for k, v in pairs(defaults) do
+        if target[k] == nil then
+            if type(v) == "table" then
+                local inner = {}
+                for k2, v2 in pairs(v) do
+                    inner[k2] = v2
+                end
+                target[k] = inner
+            else
+                target[k] = v
+            end
+        end
+    end
+end
+
+-- Runs after ADDON_LOADED (queued via A.OnLoad below). The SavedVariables
+-- globals exist by now: either a saved table, an empty table on first login,
+-- or nil which we replace with defaults.
+function db.Init()
+    if AegisExchangeDB == nil then
+        AegisExchangeDB = DefaultAccountDB()
+    else
+        ApplyDefaults(AegisExchangeDB, DefaultAccountDB())
+    end
+
+    if AegisExchangeCharDB == nil then
+        AegisExchangeCharDB = DefaultCharDB()
+    else
+        ApplyDefaults(AegisExchangeCharDB, DefaultCharDB())
+    end
+
+    db.account = AegisExchangeDB
+    db.char    = AegisExchangeCharDB
+end
+
+-- Return the stored price record for an itemId, or nil. Scaffolding only — no
+-- scan data is written yet.
+function db.GetPrice(itemId)
+    if not db.account then return nil end
+    return db.account.prices[itemId]
+end
+
+-- Store / replace a price record for an itemId. Scaffolding only.
+function db.SetPrice(itemId, record)
+    if not db.account then return end
+    db.account.prices[itemId] = record
+end
+
+-- Register the bootstrap with the load queue.
+A.OnLoad(db.Init)

--- a/core/init.lua
+++ b/core/init.lua
@@ -1,0 +1,96 @@
+-- Aegis: Exchange
+-- core/init.lua
+--
+-- Namespace table and event dispatcher for Turtle WoW 1.18.1, which runs the
+-- ORIGINAL WoW 1.12 (vanilla) client on Lua 5.0.
+--
+-- See CLAUDE.md for the hard rules. In short, everywhere in this addon:
+--   * Lua 5.0 only  (no string.match/gmatch, no ":match()")
+--   * no "#" length operator      -> table.getn(t)
+--   * no "%" modulo operator      -> math.mod(a, b)
+--   * events use the GLOBALS event, arg1, arg2, ...  (NOT self/event/...)
+
+-- ---------------------------------------------------------------------------
+-- Namespace
+-- ---------------------------------------------------------------------------
+-- Single global table. Everything the addon exposes hangs off this.
+AegisExchange = {}
+local A = AegisExchange
+
+A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
+A.version = "0.0.1"
+
+-- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
+A.isTurtle = (TURTLE_WOW_VERSION ~= nil)
+
+-- ---------------------------------------------------------------------------
+-- Event dispatch
+-- ---------------------------------------------------------------------------
+-- Vanilla 1.12 delivers events to a frame's OnEvent script with the GLOBALS
+-- `event`, `arg1`, `arg2`, ... already set. There is no function(self, event,
+-- ...) signature on this client. We register one hidden driver frame and fan
+-- each event out to any number of registered handlers.
+
+-- eventName -> array of handler functions.
+A.eventHandlers = {}
+
+-- The driver frame. Named so FrameXML / other files can find it via getglobal.
+A.frame = CreateFrame("Frame", "AegisExchangeEventFrame")
+
+-- Register `fn` to run whenever `evt` fires. The underlying event is only
+-- registered with the driver frame the first time it is seen.
+function A.RegisterEvent(evt, fn)
+    local list = A.eventHandlers[evt]
+    if not list then
+        list = {}
+        A.eventHandlers[evt] = list
+        A.frame:RegisterEvent(evt)
+    end
+    table.insert(list, fn)
+end
+
+-- OnEvent target. Reads the vanilla event globals and forwards them to each
+-- handler as explicit args (handlers may also read the globals directly).
+function A.Dispatch()
+    local list = A.eventHandlers[event]
+    if not list then return end
+    local n = table.getn(list)
+    local i = 1
+    while i <= n do
+        list[i](event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+        i = i + 1
+    end
+end
+
+A.frame:SetScript("OnEvent", A.Dispatch)
+
+-- ---------------------------------------------------------------------------
+-- Load bootstrap
+-- ---------------------------------------------------------------------------
+-- SavedVariables (AegisExchangeDB / AegisExchangeCharDB) are nil until
+-- ADDON_LOADED fires for "Aegis_Exchange". Modules queue their init routine
+-- via A.OnLoad and we run them all once — and only once — at that point.
+A.initCallbacks = {}
+A.loaded = false
+
+-- Queue `fn` to run right after ADDON_LOADED for this addon (or immediately if
+-- we have already loaded).
+function A.OnLoad(fn)
+    if A.loaded then
+        fn()
+    else
+        table.insert(A.initCallbacks, fn)
+    end
+end
+
+A.RegisterEvent("ADDON_LOADED", function(evt, loadedName)
+    if loadedName ~= A.name then return end
+    A.loaded = true
+    local cbs = A.initCallbacks
+    local n = table.getn(cbs)
+    local i = 1
+    while i <= n do
+        cbs[i]()
+        i = i + 1
+    end
+end)

--- a/core/scan.lua
+++ b/core/scan.lua
@@ -1,0 +1,49 @@
+-- Aegis: Exchange
+-- core/scan.lua
+--
+-- Auction scanner module -- STUB. No scanning logic yet; this only stakes out
+-- the module surface. The rules the real implementation MUST follow (all from
+-- the 1.12 client; see CLAUDE.md for the authoritative list):
+--
+--   * QueryAuctionItems(name, minLevel, maxLevel, invTypeIndex, classIndex,
+--         subclassIndex, page, isUsable, qualityIndex)   -- 9 args
+--     `page` is 0-indexed. There is NO working getAll on 1.12.
+--
+--   * Poll CanSendAuctionQuery() before EVERY query; leave ~4 seconds between
+--     pages. Wait for AUCTION_ITEM_LIST_UPDATE before reading a page.
+--
+--   * Page size is 50.
+--
+--   * GetAuctionItemInfo("list", i) returns ONLY, in this order:
+--         name, texture, count, quality, canUse, level,
+--         minBid, minIncrement, buyoutPrice, bidAmount, highBidder, owner
+--     Nothing else. `owner` may be nil until the name resolves.
+
+local A = AegisExchange
+A.scan = {}
+local scan = A.scan
+
+-- Auctions returned per page by the 1.12 server.
+scan.PAGE_SIZE = 50
+
+-- Seconds to wait between page queries (throttle around CanSendAuctionQuery).
+scan.PAGE_DELAY = 4
+
+-- Scanner state. Filled in when scanning is implemented.
+scan.state = {
+    running = false,
+    page    = 0,   -- 0-indexed, matches QueryAuctionItems
+    total   = 0,   -- total auctions across all pages (GetNumAuctionItems)
+}
+
+-- Begin a full scan. STUB.
+function scan.Start()
+    -- TODO: drive QueryAuctionItems page by page, gated on
+    -- CanSendAuctionQuery() and AUCTION_ITEM_LIST_UPDATE, PAGE_SIZE per page.
+end
+
+-- Stop / reset the scanner. STUB.
+function scan.Stop()
+    scan.state.running = false
+    scan.state.page    = 0
+end

--- a/core/util.lua
+++ b/core/util.lua
@@ -1,0 +1,148 @@
+-- Aegis: Exchange
+-- core/util.lua
+--
+-- Lua 5.0 / vanilla 1.12 safe helpers.
+--   * money formatting + gold/silver/copper parsing
+--   * string split via string.gfind  (NOT string.gmatch)
+--   * small table helpers
+--
+-- Reminder of the constraints exercised here:
+--   * no "%" operator          -> math.mod(a, b)
+--   * no "#" length operator   -> table.getn(t)
+--   * no string.match/gmatch   -> string.find (with captures) / string.gfind
+
+local A = AegisExchange
+A.util = {}
+local util = A.util
+
+local COPPER_PER_SILVER = 100
+local COPPER_PER_GOLD   = 10000   -- 100 * 100
+
+-- ---------------------------------------------------------------------------
+-- Money
+-- ---------------------------------------------------------------------------
+
+-- Split a copper amount into (gold, silver, copper). Uses math.mod and
+-- math.floor because Lua 5.0 has neither the "%" operator nor integer div.
+function util.MoneyParts(copper)
+    copper = copper or 0
+    if copper < 0 then copper = -copper end
+    copper = math.floor(copper)
+    local gold   = math.floor(copper / COPPER_PER_GOLD)
+    local silver = math.floor(math.mod(copper, COPPER_PER_GOLD) / COPPER_PER_SILVER)
+    local cop    = math.mod(copper, COPPER_PER_SILVER)
+    return gold, silver, cop
+end
+
+-- Format a copper amount as a compact string like "12g 34s 56c". Leading zero
+-- denominations are dropped, but copper is always shown when the total is
+-- under one silver. Pass `colored` = true for WoW color escape codes.
+function util.FormatMoney(copper, colored)
+    local g, s, c = util.MoneyParts(copper)
+    local parts = {}
+    if colored then
+        if g > 0 then table.insert(parts, "|cffffd700" .. g .. "g|r") end
+        if s > 0 then table.insert(parts, "|cffc7c7cf" .. s .. "s|r") end
+        if c > 0 or table.getn(parts) == 0 then
+            table.insert(parts, "|cffeda55f" .. c .. "c|r")
+        end
+    else
+        if g > 0 then table.insert(parts, g .. "g") end
+        if s > 0 then table.insert(parts, s .. "s") end
+        if c > 0 or table.getn(parts) == 0 then
+            table.insert(parts, c .. "c")
+        end
+    end
+    return table.concat(parts, " ")
+end
+
+-- Parse a money string like "12g 34s 56c" (units case-insensitive, spaces
+-- optional) into total copper. Returns nil when nothing parseable is found.
+-- Uses string.gfind (Lua 5.0) with a captured pattern; NOT string.gmatch.
+function util.ParseMoney(str)
+    if type(str) ~= "string" then return nil end
+    local total = 0
+    local found = false
+    -- Each iteration yields a "<digits>" amount and a single unit letter.
+    for amount, unit in string.gfind(str, "(%d+)%s*([gscGSC])") do
+        local n = tonumber(amount)
+        if n then
+            unit = string.lower(unit)
+            if unit == "g" then
+                total = total + n * COPPER_PER_GOLD
+            elseif unit == "s" then
+                total = total + n * COPPER_PER_SILVER
+            else
+                total = total + n
+            end
+            found = true
+        end
+    end
+    if not found then return nil end
+    return total
+end
+
+-- ---------------------------------------------------------------------------
+-- Strings
+-- ---------------------------------------------------------------------------
+
+-- Split `str` on a single separator character `sep` (default: whitespace) into
+-- an array of non-empty tokens. Returns the array and its length. Uses
+-- string.gfind so it stays Lua 5.0 safe. `sep` is expected to be a plain
+-- (non-magic) character; the default handles spaces/tabs.
+function util.Split(str, sep)
+    local out = {}
+    if type(str) ~= "string" then return out, 0 end
+    local pattern
+    if sep == nil or sep == " " then
+        pattern = "[^%s]+"
+    else
+        pattern = "[^" .. sep .. "]+"
+    end
+    for token in string.gfind(str, pattern) do
+        table.insert(out, token)
+    end
+    return out, table.getn(out)
+end
+
+-- Trim leading/trailing whitespace. Uses string.gsub (fine in 5.0) with an
+-- anchored capture; NOT string.match.
+function util.Trim(str)
+    if type(str) ~= "string" then return str end
+    local result = string.gsub(str, "^%s*(.-)%s*$", "%1")
+    return result   -- discard gsub's 2nd return (substitution count)
+end
+
+-- ---------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------
+
+-- Shallow copy of an array or hash table.
+function util.CopyTable(t)
+    local out = {}
+    for k, v in pairs(t) do
+        out[k] = v
+    end
+    return out
+end
+
+-- Look for `value` in array `t`. Returns (true, index) or (false, nil).
+function util.ArrayContains(t, value)
+    local n = table.getn(t)
+    local i = 1
+    while i <= n do
+        if t[i] == value then return true, i end
+        i = i + 1
+    end
+    return false, nil
+end
+
+-- Count entries in a hash table via pairs, since table.getn only measures the
+-- contiguous array part.
+function util.CountKeys(t)
+    local n = 0
+    for _ in pairs(t) do
+        n = n + 1
+    end
+    return n
+end

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1,0 +1,56 @@
+-- Aegis: Exchange
+-- ui/frame.lua
+--
+-- Attaches an "Aegis" tab to the vanilla AuctionFrame -- STUB. Creates the tab
+-- scaffolding only; no panel contents yet.
+--
+-- The auction UI is a load-on-demand addon (Blizzard_AuctionUI): AuctionFrame
+-- does not exist until the player first opens an auctioneer. We therefore wait
+-- for that addon to load (and also try on AUCTION_HOUSE_SHOW as a fallback).
+--
+-- Dynamic frame names are resolved with getglobal(); frames are built with
+-- CreateFrame using vanilla templates (here: AuctionFrameTab).
+
+local A = AegisExchange
+A.ui = A.ui or {}
+local ui = A.ui
+
+-- Guard so we only attach our tab once.
+ui.tabAttached = false
+
+-- Create and wire our tab into the AuctionFrame tab strip. STUB.
+function ui.AttachTab()
+    if ui.tabAttached then return end
+    if not AuctionFrame then return end   -- auction UI not loaded yet
+
+    -- Blizzard tracks the tab count as AuctionFrame.numTabs (Browse/Bid/
+    -- Auctions == 3 in vanilla). Our tab takes the next index.
+    local index    = (AuctionFrame.numTabs or 3) + 1
+    local tabName  = "AegisExchangeAuctionTab"
+    local prevName = "AuctionFrameTab" .. (index - 1)
+
+    -- CreateFrame with the vanilla AuctionFrameTab template.
+    local tab = CreateFrame("Button", tabName, AuctionFrame, "AuctionFrameTab")
+    tab:SetID(index)
+    tab:SetText("Aegis")
+    tab:SetPoint("LEFT", getglobal(prevName), "RIGHT", -8, 0)
+
+    -- TODO: hook the tab into AuctionFrame's tab-switch machinery and build
+    -- the panel shown when it is selected.
+
+    AuctionFrame.numTabs = index
+    ui.tab         = tab
+    ui.tabAttached = true
+end
+
+-- Attach as soon as the auction UI addon loads.
+A.RegisterEvent("ADDON_LOADED", function(evt, loadedName)
+    if loadedName == "Blizzard_AuctionUI" then
+        ui.AttachTab()
+    end
+end)
+
+-- Fallback: if the AH is shown and we still have not attached, try now.
+A.RegisterEvent("AUCTION_HOUSE_SHOW", function()
+    ui.AttachTab()
+end)

--- a/ui/tooltip.lua
+++ b/ui/tooltip.lua
@@ -1,0 +1,44 @@
+-- Aegis: Exchange
+-- ui/tooltip.lua
+--
+-- GameTooltip hook -- STUB. Eventually adds our auction-price line to item
+-- tooltips.
+--
+-- HOOKING RULE (see CLAUDE.md): NO hooksecurefunc and NO secure hooks. On this
+-- client we hook by SAVING the original function and REPLACING it, then
+-- calling the saved original from our replacement.
+
+local A = AegisExchange
+A.tooltip = {}
+local tooltip = A.tooltip
+
+-- Guard so the hook is installed only once.
+tooltip.hooked = false
+
+-- Append our line(s) to a GameTooltip already showing an item. STUB -- reads
+-- nothing from the DB yet.
+function tooltip.AddLine(gtt, itemName, itemId)
+    -- TODO: record = A.db.GetPrice(itemId); add an AH price line, e.g.
+    --   gtt:AddLine("Aegis: " .. A.util.FormatMoney(record.market, true))
+    --   gtt:Show()   -- re-flow the tooltip after adding lines
+end
+
+-- Install the hook by saving the original method and replacing it.
+function tooltip.Install()
+    if tooltip.hooked then return end
+    if not GameTooltip then return end
+
+    -- Save the original, then replace with our wrapper. `self` is the
+    -- GameTooltip. We call the original FIRST so the default tooltip is fully
+    -- built, then we get our chance to add lines.
+    tooltip.orig_SetBagItem = GameTooltip.SetBagItem
+    GameTooltip.SetBagItem = function(self, bag, slot)
+        local ret = tooltip.orig_SetBagItem(self, bag, slot)
+        -- TODO: resolve the item from (bag, slot) and call tooltip.AddLine.
+        return ret
+    end
+
+    tooltip.hooked = true
+end
+
+A.OnLoad(tooltip.Install)


### PR DESCRIPTION
Repo skeleton for a Turtle WoW 1.18.1 (vanilla 1.12 client, Lua 5.0)
auction house helper addon.

- Aegis_Exchange.toc: Interface 11200, SavedVariables, load order
- core/init.lua: AegisExchange namespace, global-arg event dispatcher,
  ADDON_LOADED-gated OnLoad queue
- core/util.lua: Lua 5.0 safe helpers (money format/parse via math.mod +
  string.gfind, split, trim, table utils)
- core/db.lua: account/per-char SavedVariables price DB scaffolding
- core/scan.lua: auction scanner stub (documents 1.12 query rules)
- ui/frame.lua: AuctionFrame "Aegis" tab attach stub
- ui/tooltip.lua: GameTooltip hook stub (save-original + replace, no
  secure hooks)
- CLAUDE.md: hard rules for Lua 5.0 / 1.12 API / Turtle specifics

Verified: all files parse (luac -p) and load/run in a simulated vanilla
environment with no errors.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L