### PR TITLE
Vendor price tooltip line + Aegis panel cleanup

### DIFF
--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -97,31 +97,45 @@ end
 -- ---------------------------------------------------------------------------
 
 local function BuildPanel()
-    -- Content frame shown when the Aegis tab is selected. Anchored inside
-    -- AuctionFrame's usable region (below the 1.12 frame's title art).
+    -- Content frame shown when the Aegis tab is selected. It spans the whole
+    -- usable region below the title bar and draws an OPAQUE backdrop: the
+    -- AuctionFrame keeps the corner art of whichever stock tab was selected
+    -- last (Blizzard's OnClick only swaps textures for tabs 1-3), so without
+    -- this the leftover Browse/Bids/Auctions wells show through.
     local panel = CreateFrame("Frame", "AegisExchangePanel", AuctionFrame)
-    panel:SetPoint("TOPLEFT", AuctionFrame, "TOPLEFT", 22, -80)
-    panel:SetPoint("BOTTOMRIGHT", AuctionFrame, "BOTTOMRIGHT", -40, 40)
+    panel:SetPoint("TOPLEFT", AuctionFrame, "TOPLEFT", 12, -45)
+    panel:SetPoint("BOTTOMRIGHT", AuctionFrame, "BOTTOMRIGHT", -12, 35)
+    panel:SetBackdrop({
+        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        tile = true, tileSize = 16, edgeSize = 14,
+        insets = { left = 4, right = 4, top = 4, bottom = 4 },
+    })
+    panel:SetBackdropColor(0.06, 0.055, 0.04, 1)
+    panel:SetBackdropBorderColor(0.30, 0.26, 0.16)
     panel:Hide()
     ui.panel = panel
 
-    -- Header: title left, last-full-scan summary right (design 1a).
+    -- Title, centered in the AuctionFrame's title bar (the stock panels each
+    -- carry their own title there and take it with them when hidden).
+    -- Parented to the panel so it appears/disappears with our tab.
     local title = panel:CreateFontString(
         "AegisExchangePanelTitle", "ARTWORK", "GameFontNormal")
-    title:SetPoint("TOPLEFT", panel, "TOPLEFT", 4, -2)
+    title:SetPoint("TOP", AuctionFrame, "TOP", 0, -18)
     title:SetText("Aegis: Exchange")
     ui.title = title
 
+    -- Last-full-scan summary, top right inside the panel (design 1a).
     local lastScanText = panel:CreateFontString(
         "AegisExchangeLastScanText", "ARTWORK", "GameFontHighlightSmall")
-    lastScanText:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -4, -4)
+    lastScanText:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -12)
     lastScanText:SetJustifyH("RIGHT")
     ui.lastScanText = lastScanText
 
     -- The scan strip: a recessed well holding buttons, bar, and status text.
     local strip = CreateFrame("Frame", "AegisExchangeScanStrip", panel)
-    strip:SetPoint("TOPLEFT", panel, "TOPLEFT", 0, -22)
-    strip:SetPoint("TOPRIGHT", panel, "TOPRIGHT", 0, -22)
+    strip:SetPoint("TOPLEFT", panel, "TOPLEFT", 8, -30)
+    strip:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -8, -30)
     strip:SetHeight(86)
     strip:SetBackdrop({
         bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
@@ -197,6 +211,14 @@ local function BuildPanel()
     statusText:SetPoint("TOP", bar, "BOTTOM", 0, -6)
     statusText:SetJustifyH("CENTER")
     ui.statusText = statusText
+
+    -- Placeholder for the empty region below the strip (sub-tabs come in a
+    -- later phase) so it reads as intentional rather than missing.
+    local hint = panel:CreateFontString(
+        "AegisExchangeHintText", "ARTWORK", "GameFontDisableSmall")
+    hint:SetPoint("CENTER", panel, "CENTER", 0, -30)
+    hint:SetText("Scan data feeds item tooltips — browse and sell tools arrive in a later phase.")
+    ui.hint = hint
 
     -- Throttled refresh while the panel is visible. OnUpdate receives no
     -- args on this client; elapsed is the GLOBAL arg1.

--- a/ui/tooltip.lua
+++ b/ui/tooltip.lua
@@ -40,7 +40,8 @@ tooltip.hooked = false
 function tooltip.Extend(gtt, itemId, count)
     local market = A.db.MarketValue(itemId)
     local minBuy = A.db.MinBuyout(itemId)
-    if not market and not minBuy then return end
+    local vendor = A.db.GetVendor(itemId)
+    if not market and not minBuy and not vendor then return end
 
     if market then
         gtt:AddDoubleLine("Aegis Market",
@@ -55,6 +56,15 @@ function tooltip.Extend(gtt, itemId, count)
                 .. util.FormatMoney(minBuy * count, true) .. ")"
         end
         gtt:AddDoubleLine("Aegis Min Buyout", right,
+            ACCENT_R, ACCENT_G, ACCENT_B, 1, 1, 1)
+    end
+    if vendor then
+        local right = util.FormatMoney(vendor, true)
+        if count and count > 1 then
+            right = right .. " (x" .. count .. " = "
+                .. util.FormatMoney(vendor * count, true) .. ")"
+        end
+        gtt:AddDoubleLine("Aegis Vendor Price", right,
             ACCENT_R, ACCENT_G, ACCENT_B, 1, 1, 1)
     end
     gtt:Show()


### PR DESCRIPTION
Follow-ups from the successful in-game test of Phase 1 (tab, full scan 50+ pages, pause/resume, tooltips, and persistence all confirmed working).

## Vendor price in tooltips

Third line under the Aegis block:

```
Aegis Market:        1g 40s
Aegis Min Buyout:    1g 20s (x20 = 24g)
Aegis Vendor Price:  50c (x20 = 10s)
```

Shown once the item's vendor sell price has been captured — hover the item in your bags while any merchant window is open (1.12 has no sell-price API, so the tooltip-money hook is the only source). Same blue-accent styling, per-unit with the stack-total suffix.

## Panel cleanup (screenshot feedback)

- **Opaque backdrop over the whole content region.** Blizzard's `AuctionFrameTab_OnClick` only swaps the frame's corner art for tabs 1–3, so the leftover Browse/Bids/Auctions wells showed through our transparent panel as black patches. The panel now draws its own dark backdrop with a subtle border.
- **Title in the title bar.** "Aegis: Exchange" now sits centered in the AuctionFrame's title bar (which the stock panels vacate when hidden) instead of floating as a chip at the panel's top-left.
- Last-scan summary and scan strip re-anchored inside the backdrop; a muted placeholder note fills the empty region below the strip until the sub-tabs arrive in a later phase.

## Verification

`luac -p` clean; simulated-1.12 harness passes, including new assertions for the vendor line (label, per-unit value, stack suffix, absent until captured, merchant *buy* prices still excluded).

## To test in-game

1. Aegis tab: content area should now be fully covered (no black leftover wells), title centered up top.
2. Hover a bag item at any vendor once, then check its tooltip anywhere — "Aegis Vendor Price" line should appear and survive /reload.

A pfUI-matched skin is noted as a future work item once the sub-tabs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_