### PR TITLE
v0.4.1 — THE scan fix: defer the Blizzard AH hide past the client's session-close guard (+ /aex slash)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.4.0
+## Version: 0.4.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,18 @@ or silent breakage on the 1.12 / Lua 5.0 client.
     save-and-replace its `OnHide`, and while *we* are the one hiding it, skip
     the default body so the session survives. See `ui.HideBlizzardAH` /
     `ui.HookAuctionFrame` in `ui/frame.lua`.
+    - **A SECOND close path lives in `AuctionFrame_Show()`** (the client's
+      AUCTION_HOUSE_SHOW handler, verbatim from the Turtle UI source):
+      ```
+      ShowUIPanel(AuctionFrame);
+      if ( not AuctionFrame:IsVisible() ) then
+          CloseAuctionHouse();
+      end
+      ```
+      So hiding the Blizzard AH **synchronously from its own `OnShow`** also
+      kills the session. The takeover hide must be **deferred one OnUpdate
+      tick** (see `AegisExchangeHider` in `ui/frame.lua`). Hiding from our own
+      AUCTION_HOUSE_SHOW handler is safe — it runs after this guard.
 
 ### SavedVariables
 

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.4.0"
+A.version = "0.4.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)
@@ -99,6 +99,7 @@ A.RegisterEvent("ADDON_LOADED", function(evt, loadedName)
     end
     if DEFAULT_CHAT_FRAME then
         DEFAULT_CHAT_FRAME:AddMessage(
-            "Aegis: Exchange v" .. A.version .. " loaded.", 0.35, 0.78, 0.98)
+            "Aegis: Exchange v" .. A.version .. " loaded \226\128\148 /aex",
+            0.35, 0.78, 0.98)
     end
 end)

--- a/core/scan.lua
+++ b/core/scan.lua
@@ -60,7 +60,7 @@ scan.state = {
                            --   onComplete = fn(stats) }
 }
 
--- Chat trace of every scanner transition; toggled with "/aegis debug". This is
+-- Chat trace of every scanner transition; toggled with "/aex debug". This is
 -- how we tell WHICH leg a stall is on: query never sent (CanSendAuctionQuery
 -- stays false) vs. query sent but no AUCTION_ITEM_LIST_UPDATE ever arrives
 -- (dead AH session / server rejected the query).

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -107,7 +107,7 @@ function ui.BuildWindow()
 
     -- Hiding our window is the single close path: whether it's the close
     -- button, ESC, or an AUCTION_HOUSE_CLOSED from walking away, end the AH
-    -- session here. Skipped only during the /aegis hand-off to the Blizzard AH,
+    -- session here. Skipped only during the /aex hand-off to the Blizzard AH,
     -- which needs the session to stay open.
     f:SetScript("OnHide", function()
         if not ui.showBlizzard then
@@ -395,7 +395,7 @@ function ui.Refresh()
             ui.statusText:SetText(pageText)
         else
             -- Still before the first page. Say WHICH leg we're on so a stall
-            -- is diagnosable from the strip alone (see /aegis debug for the
+            -- is diagnosable from the strip alone (see /aex debug for the
             -- full trace).
             if p.sent == 0 then
                 ui.statusText:SetText(
@@ -776,6 +776,36 @@ end
 -- Lifecycle: replace the Blizzard AH window while the AH is open
 -- ---------------------------------------------------------------------------
 
+-- One-tick deferred hide of the Blizzard AH.
+--
+-- The client's AUCTION_HOUSE_SHOW path (AuctionFrame_Show() in
+-- Blizzard_AuctionUI.lua, called from UIParent.lua) is, verbatim from the
+-- Turtle UI source:
+--
+--     ShowUIPanel(AuctionFrame);
+--     if ( not AuctionFrame:IsVisible() ) then
+--         CloseAuctionHouse();
+--     end
+--
+-- So if anything hides AuctionFrame SYNCHRONOUSLY from its own OnShow, that
+-- IsVisible() check fails and the CLIENT closes the AH session — after which
+-- every QueryAuctionItems is a silent no-op (this was the "no reply — retry
+-- N" stall). The OnShow hook below therefore only QUEUES the hide; this
+-- driver performs it one OnUpdate tick later, safely past the guard. No
+-- flash is visible: our toplevel HIGH-strata window covers the Blizzard AH.
+local hider = CreateFrame("Frame", "AegisExchangeHider")
+hider:Hide()
+hider:SetScript("OnUpdate", function()
+    hider:Hide()
+    if not ui.showBlizzard and AuctionFrame and AuctionFrame:IsVisible() then
+        ui.HideBlizzardAH()
+    end
+end)
+
+function ui.QueueHideBlizzard()
+    hider:Show()
+end
+
 -- CRITICAL: AuctionFrame's XML <OnHide> runs CloseAuctionHouse(), which ends
 -- the server-side AH session — after which QueryAuctionItems does nothing and a
 -- scan just spins on "Requesting first page...". So we must NEVER let the
@@ -783,9 +813,8 @@ end
 -- session. We hook it (save-original-and-replace, no hooksecurefunc) and, when
 -- WE are the one hiding it, suppress that body so the session stays alive.
 --
--- The OnShow hook neutralises the anti-flash case the same way: the instant the
--- client shows its AH we hide it back — but through ui.HideBlizzardAH, which
--- sets the suppress flag so the hide doesn't close the session.
+-- The OnShow hook handles the client re-showing its AH — but it must NOT
+-- hide synchronously (see the hider above); it queues the hide instead.
 function ui.HookAuctionFrame()
     if ui.ahHooked then return end
     if not AuctionFrame then return end
@@ -796,7 +825,9 @@ function ui.HookAuctionFrame()
             ui.orig_AuctionFrame_OnShow()
         end
         if not ui.showBlizzard then
-            ui.HideBlizzardAH()
+            -- Deferred, never synchronous — a synchronous hide here trips
+            -- the client's IsVisible guard and closes the AH session.
+            ui.QueueHideBlizzard()
         end
     end)
 
@@ -826,7 +857,10 @@ function ui.OpenWindow()
     ui.BuildWindow()
     ui.HookAuctionFrame()
     ui.showBlizzard = false
-    ui.HideBlizzardAH()   -- hide Blizzard's AH but keep the session open
+    -- Synchronous hide is safe HERE: our AUCTION_HOUSE_SHOW handler runs
+    -- after the client's AuctionFrame_Show() has already passed its
+    -- IsVisible guard, and the OnHide suppression keeps the session open.
+    ui.HideBlizzardAH()
     ui.frame:Show()
     ui.SelectSubTab(ui.selectedSubTab or "Buy")
     ui.Refresh()
@@ -856,9 +890,13 @@ A.RegisterEvent("AUCTION_HOUSE_CLOSED", function()
     if ui.frame then ui.frame:Hide() end
 end)
 
--- /aegis        — escape hatch: show the default Blizzard AH.
--- /aegis debug  — toggle the scanner's chat trace (core/scan.lua Debug).
-SLASH_AEGISEXCHANGE1 = "/aegis"
+-- /aex (or /aegisexchange)  — escape hatch: show the default Blizzard AH.
+-- /aex debug                — toggle the scanner's chat trace.
+-- Deliberately NOT "/aegis": other addons in the user's Aegis series (Aegis:
+-- Rally Power) already own that slash, and when two addons register the same
+-- slash text the client resolves it to only ONE of them.
+SLASH_AEGISEXCHANGE1 = "/aex"
+SLASH_AEGISEXCHANGE2 = "/aegisexchange"
 SlashCmdList["AEGISEXCHANGE"] = function(msg)
     local cmd = string.lower(msg or "")
     if string.find(cmd, "debug", 1, true) then


### PR DESCRIPTION
**Heads-up:** #16 got merged while I was still pushing — the commit in this PR is the actual scan fix and was not in #16. This is the one to test. (Tip: after merging, give me a moment to confirm before pulling the addon — the title-bar version stamp tells you what you're running: this PR is **v0.4.1**.)

## Root cause of "no reply — retry N" (from your v0.4.0 screenshot)

Queries were being sent; the server never answered → dead AH session. Verified verbatim against the Turtle UI source (refaim/Turtle-WoW-UI-Source), the client's AUCTION_HOUSE_SHOW path is `AuctionFrame_Show()`:

```lua
ShowUIPanel(AuctionFrame);
if ( not AuctionFrame:IsVisible() ) then
    CloseAuctionHouse();
end
```

Our anti-flash hook hid the Blizzard AH **synchronously from inside its own OnShow**, so that `IsVisible()` check saw a hidden frame and **the client itself closed the session on every open** — before any scan even started. This is a second close path, independent of the `<OnHide>` → `CloseAuctionHouse()` one fixed earlier.

**Fix:** the OnShow hook now only *queues* the hide; a one-tick deferred driver (`AegisExchangeHider`) hides the Blizzard AH right after the guard passes, via the session-safe suppressed-OnHide path. No visible flash — our toplevel HIGH-strata window covers it. Hiding from our own AUCTION_HOUSE_SHOW handler stays immediate (it runs after the guard). Documented in CLAUDE.md rule 12.

**Proof in tests:** the simulated-1.12 harness now replays `AuctionFrame_Show()` verbatim. With the old synchronous hide it fails the "AH session stays open" assertion (tamper-verified); with this fix all checks pass.

## Slash command: `/aex`

`/aegis` collided with your **Aegis: Rally Power** — two addons registering the same slash means the client picks one and the other silently loses. Now:
- **`/aex`** (or `/aegisexchange`) — show the default Blizzard AH
- **`/aex debug`** — toggle the scanner chat trace

## To test in-game
1. Update the addon; the title bar must read **v0.4.1** and chat prints `Aegis: Exchange v0.4.1 loaded — /aex`.
2. Open the AH → **Full Scan** → Continue → it should page through for real (`Page X / Y · ETA · rate`).
3. `/aegis` now belongs to Rally Power alone; use `/aex` for this addon.
4. If it still stalls: `/aex debug`, rescan, send me the trace lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_