### PR TITLE
v0.7.1 — Sell tab: skip soulbound/non-postable items, fix bag scrollbar overlap

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.7.0
+## Version: 0.7.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.7.0"
+A.version = "0.7.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/sell.lua
+++ b/core/sell.lua
@@ -238,10 +238,54 @@ end
 -- Bag enumeration (drives the Sell tab's "Your Bags" list)
 -- ---------------------------------------------------------------------------
 
--- Walk bags 0..4 and group every item by its category (GetItemInfo's itemType).
--- Returns an ordered list of { name = className, items = { entry, ... } } where
--- entry = { bag, slot, itemId, name, texture, count }. Order follows first
--- appearance so the grouping is stable between refreshes.
+-- Tooltip phrases that mark an item you cannot put on the auction house. 1.12
+-- exposes no soulbound flag, so we read the item's tooltip text (the same trick
+-- aux / Auctionator use). Globals fall back to English literals off Turtle.
+local BLOCK_PHRASES = {
+    ITEM_SOULBOUND  or "Soulbound",
+    ITEM_BIND_QUEST or "Quest Item",
+    ITEM_CONJURED   or "Conjured Item",
+}
+
+-- Hidden tooltip we own, created lazily, for reading bind status.
+local function ScanTip()
+    if not sell._scanTip then
+        sell._scanTip = CreateFrame("GameTooltip", "AegisExchangeScanTooltip",
+            nil, "GameTooltipTemplate")
+    end
+    return sell._scanTip
+end
+
+-- True unless the bag item is soulbound / quest / conjured (i.e. postable).
+function sell.IsAuctionable(bag, slot)
+    local tip = ScanTip()
+    tip:SetOwner(UIParent, "ANCHOR_NONE")
+    tip:ClearLines()
+    tip:SetBagItem(bag, slot)
+    local n = tip:NumLines() or 0
+    local i = 2   -- line 1 is the item name; bind text sits below it
+    while i <= n do
+        local fs = getglobal("AegisExchangeScanTooltipTextLeft" .. i)
+        local txt = fs and fs:GetText()
+        if txt then
+            local b = 1
+            while b <= table.getn(BLOCK_PHRASES) do
+                if string.find(txt, BLOCK_PHRASES[b], 1, true) then
+                    return false
+                end
+                b = b + 1
+            end
+        end
+        i = i + 1
+    end
+    return true
+end
+
+-- Walk bags 0..4 and group every POSTABLE item by its category (GetItemInfo's
+-- itemType). Soulbound / quest / conjured items are skipped. Returns an ordered
+-- list of { name = className, items = { entry, ... } } where entry =
+-- { bag, slot, itemId, name, texture, count }. Order follows first appearance
+-- so the grouping is stable between refreshes.
 function sell.ScanBags()
     local order = {}
     local byCat = {}
@@ -251,7 +295,7 @@ function sell.ScanBags()
         local slot = 1
         while slot <= slots do
             local link = GetContainerItemLink(bag, slot)
-            if link then
+            if link and sell.IsAuctionable(bag, slot) then
                 local texture, count = GetContainerItemInfo(bag, slot)
                 local iname, _, _, _, _, itype = GetItemInfo(link)
                 local cname = itype or "Other"

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -677,7 +677,10 @@ function ui.BuildSellTab()
     local bagScroll = CreateFrame("ScrollFrame", "AegisExchangeBagScroll",
         panel, "FauxScrollFrameTemplate")
     bagScroll:SetPoint("TOPLEFT", panel, "TOPLEFT", 12, -156)
-    bagScroll:SetPoint("BOTTOMRIGHT", panel, "BOTTOMLEFT", 188, 10)
+    -- Right edge pulled well in (168) so the FauxScrollFrame's scrollbar, which
+    -- sits just OUTSIDE this edge, clears the listings column that starts at
+    -- x=200 -- otherwise the bar overlaps the price info.
+    bagScroll:SetPoint("BOTTOMRIGHT", panel, "BOTTOMLEFT", 168, 10)
     bagScroll:SetScript("OnVerticalScroll", function()
         FauxScrollFrame_OnVerticalScroll(BAG_ROW_H, ui.UpdateBagList)
     end)


### PR DESCRIPTION
Two fixes you flagged on the Sell tab.

## Scrollbar no longer cuts into the pricing info
The bag list's `FauxScrollFrame` scrollbar sits just outside the frame's right edge, which was at x=188 and overlapped the listings column starting at x=200. Pulled the bag scroll's right edge in to x=168 so the scrollbar has clear room and never touches the price table.

## Soulbound / non-postable items are filtered out
1.12 exposes no "soulbound" flag, so `sell.IsAuctionable` reads the item's tooltip through a hidden owned scanning tooltip (the same technique aux/Auctionator use) and skips anything showing **Soulbound**, **Quest Item**, or **Conjured Item**. `ScanBags` filters on it before grouping, so those items simply don't appear in the bag list — you can only click things you can actually post.

## Verification
`luac -p` clean; Lua 5.0 sweep clean. The harness gained a scanning-tooltip stub and a soulbound bag item, and asserts `IsAuctionable(normal)=true` / `IsAuctionable(soulbound)=false` and that the bound item is absent from the bag list. All checks pass.

## To test in-game (v0.7.1)
1. Update; title bar reads **v0.7.1**. Open AH → **Sell**.
2. The left bag list scrollbar sits clear of the price table on the right — no overlap.
3. Any soulbound gear, quest items, or conjured items in your bags are absent from the list; only postable items show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_