### PR TITLE
Crafting profit/loss estimate + searches feed the price DB (v0.11.0)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.10.0
+## Version: 0.11.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -264,6 +264,18 @@ function buy.ReadPage()
         i = i + 1
     end
 
+    -- Ordinary browsing feeds the price DB too (not just full scans): fold each
+    -- listing's unit buyout into today's daily minimum. This is what makes the
+    -- % market column and the crafting profit estimate work off searches alone.
+    local ri = 1
+    while ri <= table.getn(rows) do
+        local r = rows[ri]
+        if r.itemId and r.unit then
+            A.db.RecordAuction(r.itemId, r.unit, r.name)
+        end
+        ri = ri + 1
+    end
+
     -- Cheapest unit buyout first (bid-only auctions, unit = nil, sink to the
     -- bottom); the real `index` is preserved so buying still hits the right
     -- listing.
@@ -404,6 +416,13 @@ function craft.CaptureTradeSkill()
     if GetTradeSkillItemLink then
         itemId = util.ItemIdFromLink(GetTradeSkillItemLink(id))
     end
+    -- How many the recipe yields (for the profit estimate). Optional API on
+    -- 1.12 -- default 1 when unavailable.
+    local made = 1
+    if GetTradeSkillNumMade then
+        local minMade = GetTradeSkillNumMade(id)
+        if minMade and minMade > 0 then made = minMade end
+    end
     local reagents = {}
     local n = GetTradeSkillNumReagents(id) or 0
     local r = 1
@@ -419,7 +438,60 @@ function craft.CaptureTradeSkill()
         end
         r = r + 1
     end
-    return { name = name, itemId = itemId, reagents = reagents }
+    return { name = name, itemId = itemId, made = made, reagents = reagents }
+end
+
+-- Faction consignment cut applied to a sale on Turtle (see CLAUDE.md).
+craft.AH_CUT = 0.05
+
+-- Resolve a stored reagent/product to an itemId, using the captured link id
+-- first and the name->id map (filled by scans/searches) as a fallback.
+local function ResolveId(itemId, name)
+    if itemId then return itemId end
+    if name and A.db and A.db.IdFromName then return A.db.IdFromName(name) end
+    return nil
+end
+
+-- Total cost to buy this recipe's reagents at the best known unit price.
+-- Returns (copperTotal, complete, missingNames): complete is false (and the
+-- name is listed in missingNames) when a reagent has no recorded price yet.
+function craft.CostOf(project)
+    local total, complete, missing = 0, true, {}
+    if not project or not project.reagents then return 0, false, missing end
+    local i = 1
+    while i <= table.getn(project.reagents) do
+        local r = project.reagents[i]
+        local id = ResolveId(r.itemId, r.name)
+        local unit = id and A.db.BestUnit(id)
+        if unit then
+            total = total + unit * (r.count or 1)
+        else
+            complete = false
+            table.insert(missing, r.name)
+        end
+        i = i + 1
+    end
+    return total, complete, missing
+end
+
+-- Best known sale value of the crafted item (× quantity made). Returns
+-- (copper, known). Enchanting crafts have no item, so known is false.
+function craft.ValueOf(project)
+    if not project then return nil, false end
+    local id = ResolveId(project.itemId, project.name)
+    local unit = id and A.db.BestUnit(id)
+    if not unit then return nil, false end
+    return unit * (project.made or 1), true
+end
+
+-- Estimated net if you buy the mats, craft, and resell: sale value minus the
+-- AH cut, minus reagent cost. Returns (net, complete) where complete means
+-- both sides were fully priced.
+function craft.NetOf(project)
+    local cost, costComplete = craft.CostOf(project)
+    local value, valueKnown = craft.ValueOf(project)
+    if not (costComplete and valueKnown) then return nil, false end
+    return math.floor(value * (1 - craft.AH_CUT) - cost), true
 end
 
 -- Capture the recipe selected in the craft window (Enchanting).

--- a/core/db.lua
+++ b/core/db.lua
@@ -168,6 +168,13 @@ function db.MinBuyout(itemId)
     return rec.daily[newest]
 end
 
+-- Best "buy it now" unit price for estimates: the most recent daily minimum
+-- buyout, falling back to the market median when today's data is thin. Used by
+-- the crafting profit estimate.
+function db.BestUnit(itemId)
+    return db.MinBuyout(itemId) or db.MarketValue(itemId)
+end
+
 -- Market value: time-weighted MEDIAN of up to the last KEEP_DAYS daily
 -- minima. Each value's weight decays by DECAY per day of age, so recent days
 -- dominate slightly but a run of old data still counts. Returns nil if the

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.10.0"
+A.version = "0.11.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1274,7 +1274,7 @@ end
 -- ---------------------------------------------------------------------------
 
 local CRAFT_ROWS,  CRAFT_ROW_H  = 11, 20
-local CSIDE_ROWS,  CSIDE_ROW_H  = 15, 18
+local CSIDE_ROWS,  CSIDE_ROW_H  = 10, 18
 local CSIDE_W = 172   -- recipe-tree width (reagent lines carry a count)
 
 function ui.BuildCraftTab()
@@ -1292,7 +1292,7 @@ function ui.BuildCraftTab()
     local sideScroll = CreateFrame("ScrollFrame", "AegisExchangeCraftSideScroll",
         panel, "FauxScrollFrameTemplate")
     sideScroll:SetPoint("TOPLEFT", panel, "TOPLEFT", 10, -28)
-    sideScroll:SetPoint("BOTTOMLEFT", panel, "BOTTOMLEFT", 10, 42)
+    sideScroll:SetPoint("BOTTOMLEFT", panel, "BOTTOMLEFT", 10, 132)
     sideScroll:SetWidth(CSIDE_W)
     sideScroll:SetScript("OnVerticalScroll", function()
         FauxScrollFrame_OnVerticalScroll(CSIDE_ROW_H, ui.UpdateCraftTree)
@@ -1330,6 +1330,33 @@ function ui.BuildCraftTab()
         ui.craftSideRows[i] = row
         i = i + 1
     end
+
+    -- Profit estimate for the selected recipe (buy mats -> craft -> resell).
+    local estHdr = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    estHdr:SetPoint("BOTTOMLEFT", panel, "BOTTOMLEFT", 10, 116)
+    estHdr:SetText("Profit estimate")
+    estHdr:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
+
+    ui.craftCostFS = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    ui.craftCostFS:SetPoint("BOTTOMLEFT", panel, "BOTTOMLEFT", 10, 100)
+    ui.craftCostFS:SetWidth(CSIDE_W); ui.craftCostFS:SetJustifyH("LEFT")
+
+    ui.craftValueFS = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    ui.craftValueFS:SetPoint("BOTTOMLEFT", panel, "BOTTOMLEFT", 10, 84)
+    ui.craftValueFS:SetWidth(CSIDE_W); ui.craftValueFS:SetJustifyH("LEFT")
+
+    ui.craftNetFS = panel:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    ui.craftNetFS:SetPoint("BOTTOMLEFT", panel, "BOTTOMLEFT", 10, 64)
+    ui.craftNetFS:SetWidth(CSIDE_W); ui.craftNetFS:SetJustifyH("LEFT")
+
+    -- Fill the DB with a fresh price for the crafted item and every reagent.
+    local priceBtn = CreateFrame("Button", "AegisExchangeCraftPriceButton",
+        panel, "UIPanelButtonTemplate")
+    priceBtn:SetWidth(CSIDE_W); priceBtn:SetHeight(18)
+    priceBtn:SetPoint("BOTTOMLEFT", panel, "BOTTOMLEFT", 10, 42)
+    priceBtn:SetText("Price recipe")
+    priceBtn:SetScript("OnClick", function() ui.CraftPriceRecipe() end)
+    ui.craftPriceBtn = priceBtn
 
     -- Delete the selected recipe.
     local delBtn = CreateFrame("Button", "AegisExchangeCraftDelButton",
@@ -1531,11 +1558,13 @@ function ui.OnCraftTreeClick(e)
         ui.craftSel = e.index
         ui.craftExpanded[e.index] = not ui.craftExpanded[e.index]
         ui.RefreshCraftTree()
+        ui.UpdateCraftSummary()
     elseif e.kind == "reagent" then
         ui.craftSel = e.projIndex
         ui.craftBox:SetText(e.name)
         ui.DoCraftSearch()
         ui.RefreshCraftTree()
+        ui.UpdateCraftSummary()
     end
 end
 
@@ -1547,6 +1576,7 @@ function ui.CraftDeleteProject()
     A.craft.DeleteProject(ui.craftSel)
     ui.craftSel = nil
     ui.RefreshCraftTree()
+    ui.UpdateCraftSummary()
 end
 
 -- ---- search + results (Buy-style, shared row helpers) ------------------
@@ -1567,13 +1597,75 @@ function ui.DoCraftSearch()
     ui.craftResults = nil
     ui.UpdateCraftList()
     local ok, err = A.buy.Search(name, {
-        onResults = function(rows) ui.craftResults = rows; ui.UpdateCraftList() end,
+        onResults = function(rows)
+            ui.craftResults = rows
+            ui.UpdateCraftList()
+            ui.UpdateCraftSummary()   -- the search fed the price DB
+        end,
         onState = function() ui.RefreshCraftStatus() end,
     })
     if not ok then
         ui.craftStatus:SetText(err or "Could not search.")
     else
         ui.craftStatus:SetText("Searching...")
+    end
+end
+
+-- Price every part of the selected recipe in one go: search the crafted item
+-- (when it's an auctionable item) and each reagent, one after another, so the
+-- price DB is filled and the profit estimate resolves. Only the last search's
+-- listings remain on the right; the rest just warm the DB.
+function ui.CraftPriceRecipe()
+    if not A.buy or not A.craft then return end
+    local p = ui.craftSel and A.craft.Projects()[ui.craftSel]
+    if not p then
+        ChatMsg("Aegis: select a recipe on the left first.")
+        return
+    end
+    local q = {}
+    if p.itemId then table.insert(q, p.name) end   -- crafted item, if it's an item
+    local i = 1
+    while i <= table.getn(p.reagents) do
+        table.insert(q, p.reagents[i].name)
+        i = i + 1
+    end
+    if table.getn(q) == 0 then
+        ChatMsg("Aegis: nothing to price for this recipe.")
+        return
+    end
+    ui.craftPriceQueue = q
+    ui.CraftRunPriceQueue()
+end
+
+function ui.CraftRunPriceQueue()
+    if not ui.craftPriceQueue or table.getn(ui.craftPriceQueue) == 0 then
+        ui.craftPriceQueue = nil
+        ui.UpdateCraftSummary()
+        if ui.craftStatus then
+            ui.craftStatus:SetText("Priced \226\128\148 net updated on the left.")
+        end
+        return
+    end
+    local term = table.remove(ui.craftPriceQueue, 1)
+    ui.craftBox:SetText(term)
+    ui.craftTitle:SetText(term)
+    local ok = A.buy.Search(term, {
+        onResults = function(rows)
+            ui.craftResults = rows
+            ui.UpdateCraftList()
+            ui.UpdateCraftSummary()
+            ui.CraftRunPriceQueue()   -- next part
+        end,
+        onState = function() ui.RefreshCraftStatus() end,
+    })
+    if not ok then
+        ui.craftPriceQueue = nil
+        if ui.craftStatus then ui.craftStatus:SetText("AH busy \226\128\148 try again.") end
+        return
+    end
+    if ui.craftStatus then
+        ui.craftStatus:SetText("Pricing... ("
+            .. table.getn(ui.craftPriceQueue) .. " left)")
     end
 end
 
@@ -1605,6 +1697,51 @@ function ui.RefreshCraft()
     end
     ui.RefreshCraftTree()
     ui.UpdateCraftList()
+    ui.UpdateCraftSummary()
+end
+
+-- Paint the Cost / Sells-for / Net lines for the selected recipe.
+function ui.UpdateCraftSummary()
+    if not ui.craftCostFS then return end
+    local p = ui.craftSel and A.craft and A.craft.Projects()[ui.craftSel]
+    if not p then
+        ui.craftCostFS:SetText("Reagents: \226\128\148")
+        ui.craftValueFS:SetText("Sells for: \226\128\148")
+        ui.craftNetFS:SetText("Net: \226\128\148")
+        ui.craftNetFS:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+        return
+    end
+    local cost, complete = A.craft.CostOf(p)
+    local value, known = A.craft.ValueOf(p)
+
+    if cost > 0 and not complete then
+        ui.craftCostFS:SetText("Reagents: " .. util.FormatMoney(cost, true)
+            .. " +?")
+    elseif complete then
+        ui.craftCostFS:SetText("Reagents: " .. util.FormatMoney(cost, true))
+    else
+        ui.craftCostFS:SetText("Reagents: |cff808080? \226\128\148 Price recipe|r")
+    end
+
+    if known then
+        ui.craftValueFS:SetText("Sells for: " .. util.FormatMoney(value, true))
+    else
+        ui.craftValueFS:SetText("Sells for: |cff808080?|r")
+    end
+
+    local net, netKnown = A.craft.NetOf(p)
+    if netKnown then
+        local word = net >= 0 and "Profit: " or "Loss: "
+        ui.craftNetFS:SetText(word .. util.FormatMoney(math.abs(net), true))
+        if net >= 0 then
+            ui.craftNetFS:SetTextColor(0.30, 0.85, 0.30)
+        else
+            ui.craftNetFS:SetTextColor(0.90, 0.30, 0.30)
+        end
+    else
+        ui.craftNetFS:SetText("Net: |cff808080need prices|r")
+        ui.craftNetFS:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+    end
 end
 
 function ui.UpdateCraftList()
@@ -1676,6 +1813,7 @@ function ui.CraftCapture()
         ui.craftSel = 1               -- new project is inserted at the front
         ui.craftExpanded[1] = true
         ui.RefreshCraftTree()
+        ui.UpdateCraftSummary()
     end
 end
 


### PR DESCRIPTION
## Summary

The Crafting tab now answers **"is this recipe worth crafting?"** — for the selected recipe it shows what the reagents cost to buy vs. what the crafted item sells for, and the net **Profit / Loss**.

### Profit estimate (left column of the Crafting tab)
- **Reagents:** sum of each reagent's `count × best known unit price`.
- **Sells for:** the crafted item's best price × quantity the recipe makes.
- **Net:** `value × (1 − 5% AH cut) − reagent cost`, coloured **green for profit**, **red for loss**. Unpriced parts show `?` until priced.
- **Price recipe** button: queues an AH search for the crafted item and every reagent in turn, filling the price DB, then resolves the net in one click.

### Pricing plumbing
- **Searches now feed the price DB.** Every Buy/Crafting search folds each listing's unit buyout into the DB (previously only full scans did) — this is what makes both the `% mkt` column and the profit estimate work off searches alone, and matches CLAUDE.md's documented "browsing feeds the DB" intent.
- `craft.CostOf` / `ValueOf` / `NetOf` compute the numbers; reagents/products resolve by captured link id, falling back to the name→id map that searches fill.
- `CaptureTradeSkill` records the recipe's yield via `GetTradeSkillNumMade` (guarded as optional on 1.12), so multi-output recipes value correctly.
- `db.BestUnit(itemId)`: most-recent min buyout, market-median fallback.

### Testing
The simulated 1.12 harness gains a `GetTradeSkillNumMade` stub and end-to-end tests: search-feeds-DB, partial vs. complete reagent cost, value/net gating before prices exist, the **Price recipe** queue driven through all three sequential searches, and both the **Profit** (green) and **Loss** (red) summary states. All checks pass.

### 1.12 / Lua 5.0 compliance
No `#` / `%` / `string.match` / `gmatch`; profit math uses `math.floor`; event/hook rules unchanged. Version bumped to **0.11.0**.

> ⚠️ No new `.toc` file, so a `/reload` is enough to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_