### PR TITLE
Live Profit/Loss line on the profession window (v0.12.0)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.11.0
+## Version: 0.12.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -518,3 +518,18 @@ function craft.CaptureCraft()
     end
     return { name = name, reagents = reagents }
 end
+
+-- The recipe currently selected in whichever profession window is OPEN, as a
+-- transient project (NOT stored). Used by the live profit line on the
+-- profession window. Returns a project or (nil, reason). Craft (Enchanting)
+-- takes priority when its window is the visible one.
+function craft.Current()
+    if CraftFrame and CraftFrame.IsVisible and CraftFrame:IsVisible() then
+        return craft.CaptureCraft()
+    end
+    if TradeSkillFrame and TradeSkillFrame.IsVisible
+        and TradeSkillFrame:IsVisible() then
+        return craft.CaptureTradeSkill()
+    end
+    return nil, "No profession open."
+end

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.11.0"
+A.version = "0.12.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1833,14 +1833,112 @@ function ui.AttachCraftButton(frame, name)
     b:SetScript("OnClick", function() ui.CraftCapture() end)
 end
 
+-- A live "Profit / Loss" readout under our button on a profession window. It
+-- works with the AH CLOSED -- it reads the price DB (filled by past scans and
+-- searches), not the live AH. Two font strings: a coloured net line and a dim
+-- mats/sells breakdown.
+function ui.AttachProfLine(frame, btnName, key)
+    if not frame then return end
+    ui.profLines = ui.profLines or {}
+    if ui.profLines[key] then return end
+    local btn = getglobal(btnName)
+    local net = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    if btn then
+        net:SetPoint("TOPRIGHT", btn, "BOTTOMRIGHT", 0, -5)
+    else
+        net:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -40, -40)
+    end
+    net:SetJustifyH("RIGHT")
+    net:SetWidth(170)
+    local sub = frame:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    sub:SetPoint("TOPRIGHT", net, "BOTTOMRIGHT", 0, -2)
+    sub:SetJustifyH("RIGHT")
+    sub:SetWidth(170)
+    ui.profLines[key] = { net = net, sub = sub }
+end
+
+-- Paint the profit line for whichever profession window is currently visible,
+-- and blank the other. Cheap enough to run on a timer (a few DB lookups).
+function ui.UpdateProfLine()
+    if not A.craft or not ui.profLines then return end
+    local key
+    if CraftFrame and CraftFrame:IsVisible() and ui.profLines.craft then
+        key = "craft"
+    elseif TradeSkillFrame and TradeSkillFrame:IsVisible()
+        and ui.profLines.tradeskill then
+        key = "tradeskill"
+    end
+    -- Blank the line on any window that isn't the active one.
+    for k, refs in pairs(ui.profLines) do
+        if k ~= key then refs.net:SetText(""); refs.sub:SetText("") end
+    end
+    if not key then return end
+    local refs = ui.profLines[key]
+    local p = A.craft.Current()
+    if not p then refs.net:SetText(""); refs.sub:SetText(""); return end
+
+    local cost, complete = A.craft.CostOf(p)
+    local value, known = A.craft.ValueOf(p)
+    local net, netKnown = A.craft.NetOf(p)
+    if netKnown then
+        local word = net >= 0 and "Profit " or "Loss "
+        refs.net:SetText("Aegis: " .. word .. util.FormatMoney(math.abs(net), true))
+        if net >= 0 then
+            refs.net:SetTextColor(0.30, 0.85, 0.30)
+        else
+            refs.net:SetTextColor(0.90, 0.30, 0.30)
+        end
+        refs.sub:SetText("mats " .. util.FormatMoney(cost, true)
+            .. "  sells " .. util.FormatMoney(value, true))
+    else
+        -- Missing prices: show what we can and point at the AH.
+        refs.net:SetText("Aegis: price the mats in the AH")
+        refs.net:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+        local matsTxt
+        if cost > 0 then
+            matsTxt = "mats " .. util.FormatMoney(cost, true)
+                .. (complete and "" or " +?")
+        else
+            matsTxt = "mats ?"
+        end
+        local sellTxt = known and ("sells " .. util.FormatMoney(value, true))
+            or "sells ?"
+        refs.sub:SetText(matsTxt .. "  " .. sellTxt)
+    end
+end
+
 function ui.HookProfessionFrames()
     if TradeSkillFrame then
         ui.AttachCraftButton(TradeSkillFrame, "AegisExchangeAddTradeSkillButton")
+        ui.AttachProfLine(TradeSkillFrame,
+            "AegisExchangeAddTradeSkillButton", "tradeskill")
     end
     if CraftFrame then
         ui.AttachCraftButton(CraftFrame, "AegisExchangeAddCraftButton")
+        ui.AttachProfLine(CraftFrame, "AegisExchangeAddCraftButton", "craft")
     end
+    if ui.profPoller then ui.profPoller:Show() end
+    ui.UpdateProfLine()
 end
+
+-- Poll the open profession window so the profit line tracks the selected
+-- recipe (there is no "selection changed" event on 1.12) and picks up new
+-- prices from a scan/search. Self-idles when no profession window is open.
+ui.profPoller = CreateFrame("Frame", "AegisExchangeProfPoller")
+ui.profPoller:Hide()
+ui.profPoller._accum = 0
+ui.profPoller:SetScript("OnUpdate", function()
+    ui.profPoller._accum = ui.profPoller._accum + arg1
+    if ui.profPoller._accum < 0.3 then return end
+    ui.profPoller._accum = 0
+    local tsVis = TradeSkillFrame and TradeSkillFrame:IsVisible()
+    local crVis = CraftFrame and CraftFrame:IsVisible()
+    if not tsVis and not crVis then
+        ui.profPoller:Hide()
+        return
+    end
+    ui.UpdateProfLine()
+end)
 
 -- ---------------------------------------------------------------------------
 -- Sell tab: bag browser + per-item listing scan + post
@@ -3136,6 +3234,13 @@ A.RegisterEvent("TRADE_SKILL_SHOW", function()
 end)
 A.RegisterEvent("CRAFT_SHOW", function()
     ui.HookProfessionFrames()
+end)
+-- Stop the profit-line poller when the profession window closes.
+A.RegisterEvent("TRADE_SKILL_CLOSE", function()
+    if ui.profPoller then ui.profPoller:Hide() end
+end)
+A.RegisterEvent("CRAFT_CLOSE", function()
+    if ui.profPoller then ui.profPoller:Hide() end
 end)
 
 -- The item in the sell slot changed (placed / removed) or our auctions


### PR DESCRIPTION
## Summary

A running **Profit / Loss** estimate now shows **directly on the trade-skill and craft windows**, so you can judge a recipe while browsing your professions — **the auction house doesn't need to be open**. It reads the price DB (filled by past scans and searches), so last-known prices drive the number offline.

### What you see
Under the **"Add to Aegis"** button on the profession window:
- A coloured line — **green `Aegis: Profit 3g 40s`** or **red `Aegis: Loss 1g 20s`**.
- A dim breakdown — `mats 12g  sells 15g`.
- When prices are missing: `Aegis: price the mats in the AH`, plus whatever partial figures are known (`mats 6g +?  sells ?`).

The line tracks the recipe you have selected and updates live as you click through the list.

### How it works
- `A.craft.Current()` reads the recipe selected in whichever profession window is open (Enchanting's craft window takes priority when it's the visible one), as a transient project — no need to "Add to Aegis" first.
- `ui.UpdateProfLine` paints the active window's line (reusing `craft.CostOf` / `ValueOf` / `NetOf`) and blanks the other.
- A throttled poller (`AegisExchangeProfPoller`) drives the updates — there is no "selection changed" event on 1.12, so it polls the current selection ~3×/sec, also catching fresh prices from a scan or search. It self-idles when no profession window is open and is stopped on `TRADE_SKILL_CLOSE` / `CRAFT_CLOSE`.

### Testing
The 1.12 harness ticks the poller in its sim loop and adds tests for: the live **Profit** line, the mats/sells breakdown, the unpriced **"price the mats"** prompt, and the poller starting on show / idling on close. All checks pass.

### 1.12 / Lua 5.0 compliance
No `#` / `%` / `string.match` / `gmatch`; the profit line is a plain FontString pair anchored to our own button (no secure hooks); money via `math.floor` + `util.FormatMoney`. Version bumped to **0.12.0**.

> ⚠️ No new `.toc` file, so a `/reload` is enough to pick this up.
> Placement note: the line sits just under the "Add to Aegis" button (top-right of the window). If you'd rather have it elsewhere (e.g. down by the Create button), say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_