### PR TITLE
UI placement fixes: profit line, craft Search button, pfUI buttons (v0.12.1)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.12.0
+## Version: 0.12.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.12.0"
+A.version = "0.12.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1384,10 +1384,12 @@ function ui.BuildCraftTab()
     box:SetScript("OnEscapePressed", function() box:ClearFocus() end)
     ui.craftBox = box
 
+    -- Search button sits to the RIGHT of the box (not below it), so the yellow
+    -- label never lands on the "Item" column header underneath.
     local searchBtn = CreateFrame("Button", "AegisExchangeCraftSearchButton",
         panel, "UIPanelButtonTemplate")
     searchBtn:SetWidth(64); searchBtn:SetHeight(20)
-    searchBtn:SetPoint("TOPLEFT", box, "BOTTOMLEFT", 0, -6)
+    searchBtn:SetPoint("LEFT", box, "RIGHT", 10, 0)
     searchBtn:SetText("Search")
     searchBtn:SetScript("OnClick", function() ui.DoCraftSearch() end)
 
@@ -1412,7 +1414,7 @@ function ui.BuildCraftTab()
     prevBtn:SetScript("OnClick", function() if A.buy then A.buy.PrevPage() end end)
 
     ui.craftStatus = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    ui.craftStatus:SetPoint("TOPLEFT", searchBtn, "BOTTOMLEFT", 0, -8)
+    ui.craftStatus:SetPoint("TOPLEFT", box, "BOTTOMLEFT", 0, -8)
     ui.craftStatus:SetJustifyH("LEFT")
     ui.craftStatus:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
     ui.craftStatus:SetText("Click a reagent on the left to shop for it.")
@@ -1822,12 +1824,17 @@ end
 function ui.AttachCraftButton(frame, name)
     if not frame or getglobal(name) then return end
     local b = CreateFrame("Button", name, frame, "UIPanelButtonTemplate")
-    b:SetWidth(96); b:SetHeight(20)
+    b:SetWidth(88); b:SetHeight(20)
     local close = getglobal(frame:GetName() .. "CloseButton")
-    if close then
-        b:SetPoint("RIGHT", close, "LEFT", -4, 0)
+    if pfUI and close then
+        -- pfUI packs its window header tight against a small corner X; drop our
+        -- button a row below the close button so it doesn't sit on the X or the
+        -- "Improves skill" checkbox.
+        b:SetPoint("TOPRIGHT", close, "BOTTOMRIGHT", 0, -2)
+    elseif close then
+        b:SetPoint("RIGHT", close, "LEFT", -8, 0)   -- a touch more gap from the X
     else
-        b:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -40, -14)
+        b:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -44, -14)
     end
     b:SetText("Add to Aegis")
     b:SetScript("OnClick", function() ui.CraftCapture() end)
@@ -1841,19 +1848,17 @@ function ui.AttachProfLine(frame, btnName, key)
     if not frame then return end
     ui.profLines = ui.profLines or {}
     if ui.profLines[key] then return end
-    local btn = getglobal(btnName)
+    -- Anchor to the frame's BOTTOM-RIGHT, in the empty area above the
+    -- Create/Exit buttons -- clear of the skill progress bar up top and of any
+    -- buttons. Sub line sits just below the net line.
     local net = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    if btn then
-        net:SetPoint("TOPRIGHT", btn, "BOTTOMRIGHT", 0, -5)
-    else
-        net:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -40, -40)
-    end
+    net:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -18, 92)
     net:SetJustifyH("RIGHT")
-    net:SetWidth(170)
+    net:SetWidth(210)
     local sub = frame:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
     sub:SetPoint("TOPRIGHT", net, "BOTTOMRIGHT", 0, -2)
     sub:SetJustifyH("RIGHT")
-    sub:SetWidth(170)
+    sub:SetWidth(210)
     ui.profLines[key] = { net = net, sub = sub }
 end
 
@@ -3153,7 +3158,9 @@ function ui.HookAuctionFrame()
         b:SetHeight(19)
         local blizClose = getglobal("AuctionFrameCloseButton")
         if blizClose then
-            b:SetPoint("RIGHT", blizClose, "LEFT", 4, 0)
+            -- Negative gap: sit clearly to the LEFT of the X (the old +4 tucked
+            -- our right edge under the close button, crammed in pfUI).
+            b:SetPoint("RIGHT", blizClose, "LEFT", -6, 0)
         else
             b:SetPoint("TOPRIGHT", AuctionFrame, "TOPRIGHT", -60, -12)
         end


### PR DESCRIPTION
## Summary

Placement fixes from in-game testing (default UI **and** pfUI).

### 1. Profession profit line → bottom-right
It was tucked under the "Add to Aegis" button at the top and **overlapped the skill progress bar**. Moved to the frame's **bottom-right**, in the empty space above the Create/Exit buttons, clear of the progress bar and any buttons.

### 2. Crafting tab: "Search" no longer overlaps "Item"
The yellow **Search** label was falling on top of the white **Item** column header. The button now sits **to the right of the search box** instead of below it, and the status line moves under the box to match — the header row is clear.

### 3. "Add to Aegis" button in pfUI
- Nudged a little further from the X and made slightly narrower (helps both UIs).
- When **pfUI is detected**, the button drops **one row below** the close button so it no longer sits on the tight corner X or the "Improves skill" checkbox that pfUI packs into the header. Default UI placement is unchanged.

### 4. "Aegis UI" swap button on the Blizzard AH
The old `+4` offset tucked its right edge **under** the close button (crammed, especially in pfUI). Now a `-6` gap places it cleanly to the left of the X.

### Notes
- Version bumped to **0.12.1**; `/reload` is enough (no new `.toc` file).
- Harness still green. The pfUI button positions are a best-effort blind fix (I can't run pfUI here) — if the "Add to Aegis" button still isn't ideal in pfUI, send a fresh screenshot and I'll dial in the exact offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_