### PR TITLE
Fix hover error on the sell slot; harden tooltip hooks (v0.16.1)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.16.0
+## Version: 0.16.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.16.0"
+A.version = "0.16.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -2482,11 +2482,14 @@ function ui.BuildSellTab()
     slot:SetScript("OnReceiveDrag", place)
     slot:SetScript("OnEnter", function()
         local it = A.sell.GetItem()
-        if it and it.link then
-            GameTooltip:SetOwner(slot, "ANCHOR_RIGHT")
+        if not it then return end
+        GameTooltip:SetOwner(slot, "ANCHOR_RIGHT")
+        if GameTooltip.SetAuctionSellItem then
+            GameTooltip:SetAuctionSellItem()          -- the slot item, safely
+        elseif it.link and GameTooltip.SetHyperlink then
             GameTooltip:SetHyperlink(it.link)
-            GameTooltip:Show()
         end
+        GameTooltip:Show()
     end)
     slot:SetScript("OnLeave", function() GameTooltip:Hide() end)
     ui.sellSlot = slot
@@ -2700,7 +2703,7 @@ function ui.BuildSellTab()
         end)
         row:SetScript("OnEnter", function()
             local e = row.entry
-            if e and e.kind == "item" and e.item then
+            if e and e.kind == "item" and e.item and GameTooltip.SetBagItem then
                 GameTooltip:SetOwner(row, "ANCHOR_RIGHT")
                 GameTooltip:SetBagItem(e.item.bag, e.item.slot)
                 GameTooltip:Show()

--- a/ui/tooltip.lua
+++ b/ui/tooltip.lua
@@ -106,6 +106,14 @@ function resolvers.SetHyperlink(link)
     return id, 1
 end
 
+function resolvers.SetAuctionSellItem()
+    -- The item currently in the auction sell slot (8th return is the link).
+    local name, _, count, _, _, _, _, link = GetAuctionSellItemInfo()
+    local id = link and util.ItemIdFromLink(link)
+    if not id then return nil end
+    return id, count or 1
+end
+
 function resolvers.SetMerchantItem(index)
     local id = util.ItemIdFromLink(GetMerchantItemLink(index))
     if not id then return nil end
@@ -130,7 +138,12 @@ end
 -- client calls SetTooltipMoney), then calls the original, then appends our
 -- lines.
 local function HookMethod(name, source)
-    tooltip.orig[name] = GameTooltip[name]
+    -- Only hook a method that actually exists on this client; otherwise we'd
+    -- install a replacement whose "original" is nil and error the moment it is
+    -- called (e.g. GameTooltip:SetHyperlink on some 1.12 builds).
+    local orig = GameTooltip[name]
+    if type(orig) ~= "function" then return end
+    tooltip.orig[name] = orig
     GameTooltip[name] = function(self, a1, a2)
         local id, count = resolvers[name](a1, a2)
         if id then
@@ -156,12 +169,13 @@ function tooltip.Install()
     if tooltip.hooked then return end
     if not GameTooltip then return end
 
-    HookMethod("SetBagItem",       "bag")
-    HookMethod("SetInventoryItem", "inventory")
-    HookMethod("SetAuctionItem",   "auction")
-    HookMethod("SetHyperlink",     "link")
-    HookMethod("SetMerchantItem",  "merchant")
-    HookMethod("SetInboxItem",     "inbox")
+    HookMethod("SetBagItem",         "bag")
+    HookMethod("SetInventoryItem",   "inventory")
+    HookMethod("SetAuctionItem",     "auction")
+    HookMethod("SetAuctionSellItem", "sell")
+    HookMethod("SetHyperlink",       "link")
+    HookMethod("SetMerchantItem",    "merchant")
+    HookMethod("SetInboxItem",       "inbox")
 
     -- Vendor-price collection. 1.12's GetItemInfo has no sell price; the only
     -- source is the money line the client adds to bag-item tooltips while a


### PR DESCRIPTION
## Summary

Fixes the Lua error when hovering the sell-slot icon.

### Cause
The slot's hover handler called `GameTooltip:SetHyperlink`. Our tooltip system hooks that method by saving the original and replacing it — but on a client where `SetHyperlink` doesn't exist, the "saved original" was `nil`, so our replacement errored the moment it was called (which is exactly when you hovered the slot).

### Fix
- **`HookMethod` is now defensive**: it only hooks a `GameTooltip` method that actually exists, so it never installs a replacement that would call a nil original.
- The **sell slot** now uses `GameTooltip:SetAuctionSellItem()` — the correct 1.12 API for the auction sell slot (and it's hooked, so the Aegis price lines still show) — falling back to `SetHyperlink` only if present.
- Both the slot and bag-row hover handlers now guard that the tooltip method exists before calling it.

### Testing
Harness adds a `SetAuctionSellItem`/`SetOwner` stub and a sell-slot hover smoke test; the existing tooltip suite still passes under the defensive hook. All checks pass.

> Version **0.16.1**; `/reload` is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_