### PR TITLE
History tab: sales income and purchase tracking (v0.17.0)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.16.1
+## Version: 0.17.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,146 @@
+# Aegis: Exchange
+
+**A clean, fast auction house for Turtle WoW.**
+
+The stock 1.12 auction house is three text boxes and a prayer. Aegis replaces it
+with a window that actually knows what things are worth — what you should charge,
+what you should pay, whether that recipe is worth crafting, and how much gold you
+made this week.
+
+> Built for **Turtle WoW 1.18.1**, which runs the original **WoW 1.12 (vanilla)**
+> client on **Lua 5.0**. Not Classic. Not retail. Real vanilla.
+
+---
+
+## What it does
+
+### 🛒 Buy — shop like you mean it
+Search the AH, sort by unit price, stack price, or % of market value, and buy or
+bid straight from the results. Colour-coded so bargains jump out: **green is
+under market, red is over.** Keep **shopping lists** of the things you always
+need (all your tailoring mats, say) and search the whole list in one click.
+
+### 💰 Sell — price it right the first time
+Drop an item in and Aegis scans the AH for *just that item*, shows you every
+competing listing, and pre-fills your price. **Undercut** by a percentage or a
+flat amount (yes, 1 copper works). Post **multiple stacks at once** — "3 stacks
+of 20" — with an approximate deposit and your listing count against the 120-auction
+cap. Click any competitor's row to steal their price.
+
+### 📜 Auctions — mind the store
+Every auction you have out, with time left, current bid, and the thing you
+actually care about: **have I been undercut?** Green means you're still the
+cheapest. Red means someone slid under you. Cancel anything with one click.
+
+### 🔨 Crafting — is this even worth making?
+Open a profession, pick a recipe, hit **Add to Aegis**. The Crafting tab then
+lists every reagent — click one to shop for it like any other item. And it does
+the maths you were doing in your head:
+
+> **mats 12g 40s → sells 18g** · **Profit 4g 71s** *(after the 5% cut)*
+
+That same profit line shows up **right on the profession window**, live, as you
+click through recipes. It reads saved prices, so it works with the AH closed.
+
+### 📈 History — where did all the gold go?
+Sales get logged **straight from your mailbox** — open your mail and Aegis
+records every "Auction successful" for you. Purchases get logged when you buy.
+Then it tells you **Income · Spent · Net** over the last 24h, 7d, 30d, or all
+time.
+
+### 🔍 Aegis tab — scanning + settings
+Run a full scan, a category-targeted scan, or scan everything in your bags to
+price it. Pause, resume, or **stop** whenever. Plus your defaults: post duration,
+undercut rule, auto-fill price, tooltip lines, and profit line — all in one place.
+
+### 💬 Tooltips everywhere
+Every item tooltip — bags, inventory, the AH, even the mailbox — gains market
+value, minimum buyout, and vendor price, with stack totals.
+
+---
+
+## Install
+
+1. Download this repo (**Code → Download ZIP**, or clone it).
+2. Drop the folder into:
+   ```
+   World of Warcraft/Interface/AddOns/Aegis_Exchange
+   ```
+3. **The folder must be named exactly `Aegis_Exchange`** — GitHub's ZIP unpacks
+   as `Aegis_Exchange-main`, so rename it or the addon won't load.
+4. Restart the client. Visit an auctioneer.
+
+That's it. Aegis takes over the auction window automatically.
+
+---
+
+## Using it
+
+| Do this | Get that |
+|---|---|
+| Talk to an auctioneer | The Aegis window opens automatically |
+| `/aex` | Hand the session back to the stock Blizzard AH |
+| **Blizzard UI** button | Same thing, with a mouse |
+| **Aegis UI** button (on the stock AH) | Come back |
+| `/aex debug` | Verbose scanner trace, for when something looks wrong |
+
+**Prices come from scanning.** A fresh install knows nothing — run a scan (or
+just search for things; ordinary searches feed the database too) and the market
+numbers, % colours, and profit estimates fill in as you go.
+
+---
+
+## A few honest notes
+
+- **Deposits are approximate.** Turtle inflates the number the client reports, so
+  Aegis scales it and always labels it *approx*. Never treat it as exact.
+- **Turtle specifics are baked in:** durations are ×3 (6h / 24h / 72h), there's a
+  120-auction account cap, a 5% cut on sales, and the auction house is
+  **cross-faction** — one shared economy, so prices aren't split by side.
+- **Scanning is deliberately polite.** ~4 seconds between pages, because the 1.12
+  server will happily ignore you if you hammer it. A full scan takes a while;
+  that's the protocol, not the addon.
+- **Mail sale-tracking is enUS-only** right now (it matches "Auction successful:").
+
+---
+
+## Under the hood
+
+```
+Aegis_Exchange/
+├── core/
+│   ├── init.lua    namespace + event dispatcher
+│   ├── util.lua    Lua 5.0-safe helpers (money, strings, tables)
+│   ├── db.lua      price database, settings, ledger
+│   ├── scan.lua    page-by-page scanner state machine
+│   ├── sell.lua    posting engine + owned auctions
+│   └── buy.lua     search/buy engine + shopping lists + crafting
+├── ui/
+│   ├── frame.lua   the window and every tab
+│   └── tooltip.lua price lines on item tooltips
+└── design/         mockups (reference only — never loaded)
+```
+
+Market value is a **time-weighted median** of each item's daily minimum buyout
+over ~11 days, so one weird lowball doesn't wreck your numbers and a genuine
+price shift still moves them.
+
+Everything is **Lua 5.0 and 1.12 API only** — no `string.match`, no `#`, no `%`
+operator, no secure hooks. If you're contributing, `CLAUDE.md` has the full rules
+and the reasons behind them, most of which were learned the hard way.
+
+---
+
+## Contributing
+
+PRs welcome. Two requests: keep it inside the 1.12 rules in `CLAUDE.md`, and bump
+the version in both `core/init.lua` and the `.toc` so in-game bug reports say
+which build they came from.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+---
+
+*Aegis: Exchange is part of the Aegis addon series. Happy flipping.* ⚔️

--- a/core/db.lua
+++ b/core/db.lua
@@ -63,8 +63,15 @@ local function DefaultAccountDB()
         -- User settings (Aegis tab). Values are read through db.Setting, which
         -- falls back to SETTING_DEFAULTS, so a save missing a key still works.
         settings = {},
+        -- Sales & income history (History tab): a capped list of transactions,
+        -- plus dedup keys so a mailbox sale is only logged once.
+        ledger     = {},   -- array of { t, kind = "sale"|"buy", item, amount, id }
+        ledgerSeen = {},   -- dedup key -> true (AH sale mails)
     }
 end
+
+-- Cap on retained transactions so SavedVariables stays small.
+local LEDGER_MAX = 500
 
 -- Defaults for every user setting. db.Setting falls back to these, so adding a
 -- new setting here is enough -- no migration of old saves needed.
@@ -271,6 +278,63 @@ end
 function db.ClearItems()
     if not db.account then return end
     db.account.items = {}
+end
+
+-- ---------------------------------------------------------------------------
+-- Sales & income ledger (History tab)
+-- ---------------------------------------------------------------------------
+
+-- Append a transaction. kind is "sale" (money in) or "buy" (money out).
+function db.RecordTxn(kind, item, amount, itemId)
+    if not db.account then return end
+    if not amount or amount <= 0 then return end
+    local led = db.account.ledger
+    if not led then led = {}; db.account.ledger = led end
+    table.insert(led, { t = time(), kind = kind, item = item or "?",
+        amount = amount, id = itemId })
+    -- Prune oldest beyond the cap.
+    while table.getn(led) > LEDGER_MAX do
+        table.remove(led, 1)
+    end
+end
+
+function db.Ledger()
+    return (db.account and db.account.ledger) or {}
+end
+
+-- Has this mail-sale dedup key been logged already?
+function db.WasSeen(key)
+    return db.account and db.account.ledgerSeen and db.account.ledgerSeen[key]
+        and true or false
+end
+
+function db.MarkSeen(key)
+    if not db.account then return end
+    if not db.account.ledgerSeen then db.account.ledgerSeen = {} end
+    db.account.ledgerSeen[key] = true
+end
+
+-- Income / spend / count over transactions at or after `sinceEpoch` (nil = all).
+function db.LedgerTotals(sinceEpoch)
+    local income, spend, n = 0, 0, 0
+    local led = db.Ledger()
+    local i = 1
+    while i <= table.getn(led) do
+        local e = led[i]
+        if not sinceEpoch or (e.t and e.t >= sinceEpoch) then
+            if e.kind == "sale" then income = income + (e.amount or 0)
+            elseif e.kind == "buy" then spend = spend + (e.amount or 0) end
+            n = n + 1
+        end
+        i = i + 1
+    end
+    return income, spend, n
+end
+
+function db.ClearLedger()
+    if not db.account then return end
+    db.account.ledger = {}
+    db.account.ledgerSeen = {}
 end
 
 -- Number of distinct items with any recorded price data.

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.16.1"
+A.version = "0.17.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -42,7 +42,7 @@ local STALE_SECONDS = 24 * 60 * 60
 
 -- "Scan" hosts the scanner controls (Full Scan / Pause / Resume / Categories
 -- + status and progress); the others are placeholders for later stages.
-local SUBTABS = { "Buy", "Sell", "Auctions", "Crafting", "Scan" }
+local SUBTABS = { "Buy", "Sell", "Auctions", "Crafting", "History", "Scan" }
 
 -- Display label per sub-tab (internal keys stay stable). The scan tab also
 -- hosts user settings, so it reads as "Aegis".
@@ -226,7 +226,8 @@ function ui.BuildWindow()
         panel:Hide()
         -- Every tab is now a real tab (built below); no placeholders remain.
         if name ~= "Scan" and name ~= "Sell" and name ~= "Buy"
-            and name ~= "Crafting" and name ~= "Auctions" then
+            and name ~= "Crafting" and name ~= "Auctions"
+            and name ~= "History" then
             local label = panel:CreateFontString(
                 "AegisExchangePanelLabel" .. name, "OVERLAY",
                 "GameFontNormalLarge")
@@ -346,6 +347,7 @@ function ui.BuildWindow()
     ui.BuildBuyTab()
     ui.BuildCraftTab()
     ui.BuildAuctionsTab()
+    ui.BuildHistoryTab()
 
     -- Live refresh while a scan runs (elapsed is the GLOBAL arg1). Only ticks
     -- while the window is shown, i.e. while the AH is open.
@@ -1528,7 +1530,10 @@ function ui.DoBuyout()
     if not ok then
         ChatMsg("Aegis: " .. (err or "buyout failed."))
     else
+        -- Log the spend for the History tab.
+        A.db.RecordTxn("buy", row.name, row.buyout, row.itemId)
         ChatMsg("Aegis: bought " .. row.name .. " x" .. row.count .. ".")
+        if ui.selectedSubTab == "History" then ui.RefreshHistory() end
     end
 end
 
@@ -2442,6 +2447,239 @@ function ui.DoCancelAuction()
         ChatMsg("Aegis: cancelled " .. r.name .. " x" .. r.count .. ".")
     end
 end
+
+-- ---------------------------------------------------------------------------
+-- History tab: sales income (from the mailbox) + purchases (from the Buy tab),
+-- with totals over a selectable window.
+-- ---------------------------------------------------------------------------
+
+local HIST_ROWS, HIST_ROW_H = 12, 20
+-- Period options: label + window seconds (0 = all time).
+local HIST_PERIODS = {
+    { label = "24h", secs = 86400 },
+    { label = "7d",  secs = 7 * 86400 },
+    { label = "30d", secs = 30 * 86400 },
+    { label = "All", secs = 0 },
+}
+
+-- Pull the item name out of an AH "sold" mail subject. enUS: the subject is
+-- "Auction successful: <item>". Returns the item name, or nil for other mail.
+local function AuctionSoldItem(subject)
+    if not subject then return nil end
+    local s, e = string.find(subject, "Auction successful: ", 1, true)
+    if s == 1 then return string.sub(subject, e + 1) end
+    return nil
+end
+
+-- Scan the open mailbox for AH sale mails and log each one once (deduped by an
+-- approximate arrival time so the same mail isn't re-counted across sessions).
+function ui.ScanMailSales()
+    if not GetInboxNumItems then return end
+    local n = GetInboxNumItems() or 0
+    local i = 1
+    while i <= n do
+        local _, _, sender, subject, money, _, daysLeft = GetInboxHeaderInfo(i)
+        local item = AuctionSoldItem(subject)
+        if item and money and money > 0 then
+            -- Arrival epoch is stable as daysLeft falls and `now` rises; bucket
+            -- to the hour for a key that survives relogins.
+            local arrival = math.floor((time() - (daysLeft or 0) * 86400) / 3600)
+            local key = subject .. "|" .. money .. "|" .. arrival
+            if not A.db.WasSeen(key) then
+                A.db.MarkSeen(key)
+                A.db.RecordTxn("sale", item, money)
+            end
+        end
+        i = i + 1
+    end
+    if ui.selectedSubTab == "History" then ui.RefreshHistory() end
+end
+
+function ui.BuildHistoryTab()
+    local panel = ui.panels["History"]
+    if not panel or ui.histBuilt then return end
+    ui.histBuilt = true
+    ui.histPeriod = 2   -- default to 7d
+
+    -- Period buttons.
+    local perLbl = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    perLbl:SetPoint("TOPLEFT", panel, "TOPLEFT", 10, -14)
+    perLbl:SetText("Period:")
+    perLbl:SetTextColor(C.text[1], C.text[2], C.text[3])
+
+    ui.histPerBtns = {}
+    local prev = nil
+    local pi = 1
+    while pi <= table.getn(HIST_PERIODS) do
+        local b = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+        b:SetWidth(44); b:SetHeight(20)
+        if prev then b:SetPoint("LEFT", prev, "RIGHT", 4, 0)
+        else b:SetPoint("LEFT", perLbl, "RIGHT", 8, 0) end
+        b:SetText(HIST_PERIODS[pi].label)
+        b.idx = pi
+        b:SetScript("OnClick", function()
+            ui.histPeriod = b.idx
+            ui.RefreshHistory()
+        end)
+        ui.histPerBtns[pi] = b
+        prev = b
+        pi = pi + 1
+    end
+
+    local clearBtn = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+    clearBtn:SetWidth(100); clearBtn:SetHeight(20)
+    clearBtn:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -10, -12)
+    clearBtn:SetText("Clear history")
+    clearBtn:SetScript("OnClick", function()
+        StaticPopup_Show("AEGIS_EXCHANGE_CLEARLEDGER")
+    end)
+
+    -- Totals line.
+    ui.histTotals = panel:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    ui.histTotals:SetPoint("TOPLEFT", panel, "TOPLEFT", 10, -42)
+    ui.histTotals:SetJustifyH("LEFT")
+
+    ui.histNote = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    ui.histNote:SetPoint("TOPLEFT", panel, "TOPLEFT", 10, -62)
+    ui.histNote:SetJustifyH("LEFT")
+    ui.histNote:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+    ui.histNote:SetText("Sales are logged from your mailbox; buys from the Buy tab.")
+
+    -- Column headers.
+    local rowLeft = 6
+    local HCX = { when = 2, kind = 92, item = 176, amount = 470 }
+    ui.histCols = HCX
+    local hdr = function(cx, text, just)
+        local fs = panel:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+        fs:SetPoint("TOPLEFT", panel, "TOPLEFT", rowLeft + cx, -84)
+        fs:SetText(text)
+        if just then fs:SetJustifyH(just) end
+        return fs
+    end
+    hdr(HCX.when, "When")
+    hdr(HCX.kind, "Type")
+    hdr(HCX.item, "Item")
+    hdr(HCX.amount, "Amount", "RIGHT")
+
+    local scroll = CreateFrame("ScrollFrame", "AegisExchangeHistScroll",
+        panel, "FauxScrollFrameTemplate")
+    scroll:SetPoint("TOPLEFT", panel, "TOPLEFT", rowLeft, -100)
+    scroll:SetPoint("BOTTOMRIGHT", panel, "BOTTOMRIGHT", -28, 10)
+    scroll:SetScript("OnVerticalScroll", function()
+        FauxScrollFrame_OnVerticalScroll(HIST_ROW_H, ui.UpdateHistoryList)
+    end)
+    ui.histScroll = scroll
+
+    ui.histRows = {}
+    local i = 1
+    while i <= HIST_ROWS do
+        local row = CreateFrame("Frame", nil, panel)
+        row:SetHeight(HIST_ROW_H)
+        if i == 1 then
+            row:SetPoint("TOPLEFT", scroll, "TOPLEFT", 0, 0)
+            row:SetPoint("TOPRIGHT", scroll, "TOPRIGHT", 0, 0)
+        else
+            row:SetPoint("TOPLEFT", ui.histRows[i - 1], "BOTTOMLEFT", 0, 0)
+            row:SetPoint("TOPRIGHT", ui.histRows[i - 1], "BOTTOMRIGHT", 0, 0)
+        end
+        local mk = function(cx, w, just)
+            local fs = row:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+            fs:SetPoint("LEFT", row, "LEFT", cx, 0)
+            fs:SetWidth(w); fs:SetJustifyH(just or "LEFT")
+            return fs
+        end
+        row.when   = mk(HCX.when, 86)
+        row.kind   = mk(HCX.kind, 80)
+        row.item   = mk(HCX.item, 290)
+        row.amount = mk(HCX.amount, 96, "RIGHT")
+        row:Hide()
+        ui.histRows[i] = row
+        i = i + 1
+    end
+end
+
+function ui.RefreshHistory()
+    if not ui.histBuilt then return end
+    -- Highlight the active period button.
+    local pi = 1
+    while pi <= table.getn(ui.histPerBtns) do
+        local b = ui.histPerBtns[pi]
+        if b.idx == ui.histPeriod then b:LockHighlight() else b:UnlockHighlight() end
+        pi = pi + 1
+    end
+
+    local secs = HIST_PERIODS[ui.histPeriod].secs
+    local since = (secs > 0) and (time() - secs) or nil
+    local income, spend = A.db.LedgerTotals(since)
+    local net = income - spend
+    local netColor
+    if net >= 0 then netColor = "|cff4cd94c" else netColor = "|cffe64c4c" end
+    ui.histTotals:SetText(
+        "Income " .. util.FormatMoney(income, true)
+        .. "   Spent " .. util.FormatMoney(spend, true)
+        .. "   Net " .. netColor .. util.FormatMoney(math.abs(net), true) .. "|r")
+
+    -- Build the display list (most recent first) within the window.
+    local led = A.db.Ledger()
+    ui.histView = {}
+    local i = table.getn(led)
+    while i >= 1 do
+        local e = led[i]
+        if not since or (e.t and e.t >= since) then
+            table.insert(ui.histView, e)
+        end
+        i = i - 1
+    end
+    ui.UpdateHistoryList()
+end
+
+function ui.UpdateHistoryList()
+    if not ui.histScroll then return end
+    local rows = ui.histView or {}
+    local total = table.getn(rows)
+    FauxScrollFrame_Update(ui.histScroll, total, HIST_ROWS, HIST_ROW_H)
+    local offset = FauxScrollFrame_GetOffset(ui.histScroll)
+    local i = 1
+    while i <= HIST_ROWS do
+        local row = ui.histRows[i]
+        local e = rows[i + offset]
+        if e then
+            row.when:SetText(e.t and util.FormatAgo(time() - e.t) or "\226\128\148")
+            row.when:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+            if e.kind == "sale" then
+                row.kind:SetText("Sold")
+                row.kind:SetTextColor(0.30, 0.85, 0.30)
+                row.amount:SetText("+" .. util.FormatMoney(e.amount, true))
+            else
+                row.kind:SetText("Bought")
+                row.kind:SetTextColor(0.90, 0.55, 0.35)
+                row.amount:SetText("-" .. util.FormatMoney(e.amount, true))
+            end
+            row.item:SetText(e.item or "?")
+            row.item:SetTextColor(C.text[1], C.text[2], C.text[3])
+            row:Show()
+        else
+            row:Hide()
+        end
+        i = i + 1
+    end
+    if total == 0 then
+        ui.histNote:SetText("No transactions in this period yet.")
+    else
+        ui.histNote:SetText("Sales are logged from your mailbox; buys from the Buy tab.")
+    end
+end
+
+StaticPopupDialogs["AEGIS_EXCHANGE_CLEARLEDGER"] = {
+    text = "Clear ALL Aegis sales/income history?\nThis cannot be undone.",
+    button1 = "Clear", button2 = "Cancel",
+    OnAccept = function()
+        A.db.ClearLedger()
+        ui.RefreshHistory()
+        ChatMsg("Aegis: history cleared.")
+    end,
+    timeout = 0, whileDead = 1, hideOnEscape = 1,
+}
 
 -- ---------------------------------------------------------------------------
 -- Sell tab: bag browser + per-item listing scan + post
@@ -3712,6 +3950,8 @@ function ui.SelectSubTab(name)
         ui.RefreshCraft()
     elseif name == "Auctions" then
         ui.RefreshAuctions(true)
+    elseif name == "History" then
+        ui.RefreshHistory()
     elseif name == "Scan" then
         ui.RefreshSettings()   -- keep the price-data count current
     end
@@ -3898,6 +4138,12 @@ end)
 A.RegisterEvent("AUCTION_OWNED_LIST_UPDATE", function()
     ui.RefreshSell()
     if ui.aucBuilt then ui.RefreshAuctions(false) end
+end)
+
+-- The mailbox updated (opened one, or took mail): log any AH sale mail so the
+-- History tab tracks income even when the AH window isn't open.
+A.RegisterEvent("MAIL_INBOX_UPDATE", function()
+    ui.ScanMailSales()
 end)
 -- Bags changed (looted, moved, sold): refresh the Sell tab's bag browser, but
 -- only while it's the visible tab so we don't rescan bags needlessly.


### PR DESCRIPTION
## Summary

Adds a **History** tab that tracks what you've sold and bought, with totals over a selectable period.

### Where the data comes from
- **Sales — from your mailbox.** On `MAIL_INBOX_UPDATE` Aegis reads the inbox headers and logs every **"Auction successful: &lt;item&gt;"** mail with its money. This works with the **AH closed** — just opening your mail records the income.
  - Each mail is logged **once**: deduped by subject + money + approximate arrival hour, so reopening the mailbox or relogging never double-counts.
- **Purchases — from the Buy tab.** A confirmed buyout records the spend against that item.

### What you see
- **Income / Spent / Net** for the selected period, with Net coloured **green** (up) or **red** (down).
- Period buttons: **24h · 7d · 30d · All**.
- A most-recent-first list: *when · Sold/Bought · item · +/− amount* (sales green `+`, buys orange `−`).
- **Clear history** wipes the ledger (confirmed).

### Storage
`db.RecordTxn` / `Ledger` / `LedgerTotals` / `WasSeen` / `MarkSeen` / `ClearLedger`. The ledger is capped at **500 entries** so SavedVariables stays small, and the new keys are seeded by `ApplyDefaults` — existing saves need no migration.

### Testing
Harness gains mailbox header stubs and History tests: sale-mail logging, non-AH mail ignored, **rescan dedup**, totals, buy-as-spend, newest-first ordering with +/− signs, the period filter, and clear. All checks pass — including against the newly merged bag-scan work from #36 (no overlap: that lives in the Scan tab, this adds a new one).

### Known limitation
The mail subject match is **enUS** (`"Auction successful: "`). On a localized client sales wouldn't be detected — easy to extend with more prefixes if you need it.

> Version **0.17.0**; `/reload` is enough (no new `.toc` file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_