### PR TITLE
Move the merchant button clear of pfUI's layout (v0.19.1)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.19.0
+## Version: 0.19.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.19.0"
+A.version = "0.19.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -3778,7 +3778,13 @@ function ui.AttachMerchantButton()
         local b = CreateFrame("Button", "AegisExchangeMerchantSellButton",
             MerchantFrame, "UIPanelButtonTemplate")
         b:SetWidth(150); b:SetHeight(22)
-        b:SetPoint("BOTTOMLEFT", MerchantFrame, "BOTTOMLEFT", 22, 52)
+        -- Anchor OUTSIDE the frame, just above its top-right corner. The
+        -- merchant window's INSIDE layout differs a lot between the stock UI
+        -- and pfUI (pfUI packs the Merchant/Buyback tabs and a money row along
+        -- the bottom, which the old bottom-left spot landed on), so sitting
+        -- outside is the one placement that is clear in both.
+        b:SetPoint("BOTTOMRIGHT", MerchantFrame, "TOPRIGHT", -4, 4)
+        b:SetFrameStrata("HIGH")
         b:SetScript("OnClick", function() ui.ConfirmSellMarked() end)
         ui.merchantBtn = b
     end


### PR DESCRIPTION
## Summary

The **"Aegis: sell N marked"** button sat inside the merchant frame's bottom-left, which lands right on the **Merchant / Buyback tabs** under pfUI (see screenshot in the thread).

Moved it **outside the frame** — just above the top-right corner, on the HIGH strata.

The merchant window's *inside* layout differs a lot between the stock UI and pfUI (pfUI packs the tabs and a money row along the bottom), so anchoring outside is the one placement that stays clear in **both** — same approach that fixed the profession-window button earlier.

> Version **0.19.1**; `/reload` is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_