### PR TITLE
pfUI skin support + README vendor docs (v0.20.0)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.19.1
+## Version: 0.20.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 
@@ -12,4 +12,5 @@ core\scan.lua
 core\sell.lua
 core\buy.lua
 ui\frame.lua
+ui\skin.lua
 ui\tooltip.lua

--- a/README.md
+++ b/README.md
@@ -27,6 +27,29 @@ flat amount (yes, 1 copper works). Post **multiple stacks at once** — "3 stack
 of 20" — with an approximate deposit and your listing count against the 120-auction
 cap. Click any competitor's row to steal their price.
 
+A **History** panel shows what your scans say the item is worth (median, the
+range you've seen, how many days of data) next to what it has **actually sold
+for** from your mailbox. And after a **bag scan**, Aegis loads the first item
+into the sell slot and walks you down the list — **Post** or **Skip** moves to
+the next one, so you can clear a full bag without clicking back and forth.
+
+### 🏪 Vendor list — some things just aren't worth listing
+Not everything belongs on the auction house. Hit **Vendor** on the Sell tab and
+Aegis shows the bag items worth **more at a merchant** than on the AH — comparing
+the vendor price against the best AH price *after the 5% cut* — sorted by what
+you'd actually gain:
+
+| Item | Qty | Vendor (ea) | AH net (ea) | You gain |
+|---|---|---|---|---|
+| Tough Jerky | x5 | 25c | 9c | +80c |
+
+**Tick the ones you want gone** (or *Mark all*). Then at any merchant, an Aegis
+button appears on the vendor window — **"Aegis: sell 6 marked"** — which confirms
+what's about to go, sells the lot, and logs the gold to your History.
+
+> Vendor prices are learned by **hovering items at a merchant** (1.12's API
+> doesn't expose them otherwise), so this list fills in as you play.
+
 ### 📜 Auctions — mind the store
 Every auction you have out, with time left, current bid, and the thing you
 actually care about: **have I been undercut?** Green means you're still the
@@ -51,11 +74,38 @@ time.
 ### 🔍 Aegis tab — scanning + settings
 Run a full scan, a category-targeted scan, or scan everything in your bags to
 price it. Pause, resume, or **stop** whenever. Plus your defaults: post duration,
-undercut rule, auto-fill price, tooltip lines, and profit line — all in one place.
+undercut rule (% or flat), auto-fill price, tooltip lines, profit line, and the
+pfUI skin — all in one place.
 
 ### 💬 Tooltips everywhere
 Every item tooltip — bags, inventory, the AH, even the mailbox — gains market
 value, minimum buyout, and vendor price, with stack totals.
+
+---
+
+## Using pfUI?
+
+Aegis notices and **restyles itself to match** — pfUI's borders, buttons,
+checkboxes and scrollbars instead of vanilla tooltip frames. Nothing to install;
+it just happens. Turn it off any time with **"Match pfUI's look"** on the Aegis
+tab (takes a `/reload`).
+
+The skinning is purely cosmetic and fully guarded — if pfUI changes its API,
+the worst case is Aegis keeps its default look. It never affects behaviour.
+
+<details>
+<summary>Using <b>pfUI-addonskinner</b>?</summary>
+
+Aegis skins itself, so you don't need this. But if you prefer managing every
+skin through [pfUI-addonskinner](https://github.com/mrrosh/pfUI-addonskinner):
+
+1. Copy `pfui/Aegis_Exchange.lua` from this repo to
+   `Interface/AddOns/pfUI-addonskinner/skins/Aegis_Exchange.lua`
+2. Add `skins\Aegis_Exchange.lua` to `pfUI-addonskinner.toc` under `# skins`
+3. Restart the client
+
+That file just calls Aegis's own skinning routine, so both paths stay identical.
+</details>
 
 ---
 
@@ -117,7 +167,9 @@ Aegis_Exchange/
 │   └── buy.lua     search/buy engine + shopping lists + crafting
 ├── ui/
 │   ├── frame.lua   the window and every tab
+│   ├── skin.lua    optional pfUI restyling
 │   └── tooltip.lua price lines on item tooltips
+├── pfui/           drop-in skin for pfUI-addonskinner (not loaded by Aegis)
 └── design/         mockups (reference only — never loaded)
 ```
 

--- a/core/db.lua
+++ b/core/db.lua
@@ -86,6 +86,7 @@ local SETTING_DEFAULTS = {
     sellDefault    = "undercut", -- slot prefill: "undercut"|"market"|"none"
     tooltip        = true,      -- show Aegis price lines on item tooltips
     profLine       = true,      -- show the profit line on profession windows
+    pfSkin         = true,      -- match pfUI's look when pfUI is installed
 }
 
 -- Read a user setting, falling back to its default when unset.

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.19.1"
+A.version = "0.20.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/pfui/Aegis_Exchange.lua
+++ b/pfui/Aegis_Exchange.lua
@@ -1,0 +1,27 @@
+-- Aegis: Exchange -- skin for pfUI-addonskinner
+--
+-- OPTIONAL. Aegis skins itself when pfUI is present, so you do not need this
+-- file. It exists for people who manage every skin through
+-- pfUI-addonskinner (https://github.com/mrrosh/pfUI-addonskinner) and want
+-- Aegis to appear in that addon's list with the rest.
+--
+-- To use it:
+--   1. Copy this file to  Interface/AddOns/pfUI-addonskinner/skins/Aegis_Exchange.lua
+--   2. Add this line to pfUI-addonskinner.toc, under "# skins":
+--          skins\Aegis_Exchange.lua
+--   3. Restart the client.
+--
+-- All it does is call Aegis's own skinning routine, so the look stays in one
+-- place and cannot drift between the two paths.
+
+pfUI.addonskinner:RegisterSkin("Aegis_Exchange", function()
+    if AegisExchange and AegisExchange.skin then
+        -- The window is built lazily (first time you open the auction house),
+        -- so Apply() is also re-run from Aegis itself after the build. Calling
+        -- it here covers the case where the window already exists.
+        AegisExchange.skin.Apply()
+    end
+
+    -- Remove from the pending list now that it has been applied.
+    pfUI.addonskinner:UnregisterSkin("Aegis_Exchange")
+end)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -367,6 +367,10 @@ function ui.BuildWindow()
         end
     end)
 
+    -- Match pfUI's look when pfUI is installed (purely cosmetic, and a no-op
+    -- otherwise). Runs last so every widget above already exists.
+    if A.skin then A.skin.Apply() end
+
     -- Land on Buy (the most-used tab); Buy / Sell / Scan are all functional.
     ui.SelectSubTab("Buy")
     ui.Refresh()
@@ -530,9 +534,25 @@ function ui.BuildAegisSettings(panel, anchorAbove)
     end)
     ui.setProfLine = profChk
 
+    -- pfUI skin toggle. Only meaningful with pfUI installed, and changing it
+    -- takes effect on the next /reload (we can't un-skin frames in place).
+    local pfChk = CreateFrame("CheckButton", "AegisExchangeSetPfSkin", panel,
+        "UICheckButtonTemplate")
+    pfChk:SetWidth(24); pfChk:SetHeight(24)
+    pfChk:SetPoint("TOPLEFT", profChk, "BOTTOMLEFT", 0, -4)
+    local pfTxt = getglobal(pfChk:GetName() .. "Text")
+    if pfTxt then
+        pfTxt:SetText("Match pfUI's look (needs /reload)")
+        pfTxt:SetTextColor(C.text[1], C.text[2], C.text[3])
+    end
+    pfChk:SetScript("OnClick", function()
+        A.db.SetSetting("pfSkin", pfChk:GetChecked() and true or false)
+    end)
+    ui.setPfSkin = pfChk
+
     -- ---- Price data -------------------------------------------------------
     ui.setDataText = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    ui.setDataText:SetPoint("TOPLEFT", profChk, "BOTTOMLEFT", 4, -14)
+    ui.setDataText:SetPoint("TOPLEFT", pfChk, "BOTTOMLEFT", 4, -14)
     ui.setDataText:SetTextColor(C.text[1], C.text[2], C.text[3])
 
     local clearBtn = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
@@ -611,6 +631,15 @@ function ui.RefreshSettings()
     end
     if ui.setProfLine then
         ui.setProfLine:SetChecked(A.db.Setting("profLine") ~= false and 1 or nil)
+    end
+    if ui.setPfSkin then
+        ui.setPfSkin:SetChecked(A.db.Setting("pfSkin") ~= false and 1 or nil)
+        -- Without pfUI the toggle does nothing; grey it out rather than lie.
+        if A.skin and A.skin.Available() then
+            ui.setPfSkin:Enable()
+        else
+            ui.setPfSkin:Disable()
+        end
     end
     if ui.setDataText then
         ui.setDataText:SetText("Price data: " .. A.db.ItemCount()
@@ -2139,6 +2168,7 @@ function ui.AttachCraftButton(frame, name)
     b:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -16, 46)
     b:SetText("Add to Aegis")
     b:SetScript("OnClick", function() ui.CraftCapture() end)
+    if A.skin then A.skin.ApplyExternal() end
 end
 
 -- A live "Profit / Loss" readout under our button on a profession window. It
@@ -3747,6 +3777,7 @@ end
 
 function ui.ShowVendorList()
     ui.BuildVendorList()
+    if A.skin then A.skin.ApplyOverlay(ui.vendList) end
     ui.RefreshVendorList()
     ui.vendList:Show()
 end
@@ -3787,6 +3818,7 @@ function ui.AttachMerchantButton()
         b:SetFrameStrata("HIGH")
         b:SetScript("OnClick", function() ui.ConfirmSellMarked() end)
         ui.merchantBtn = b
+        if A.skin then A.skin.ApplyExternal() end
     end
     ui.RefreshMerchantButton()
 end
@@ -4348,6 +4380,7 @@ end
 
 function ui.ShowPicker()
     ui.BuildCategoryPicker()
+    if A.skin then A.skin.ApplyOverlay(ui.picker) end
     if not ui.catTree then
         ui.catTree = A.scan.GetCategories()
         ui.catExpanded = {}
@@ -4375,17 +4408,29 @@ end
 -- Sub-tab switching
 -- ---------------------------------------------------------------------------
 
+-- Tint a sub-tab. Under the pfUI skin the visible backdrop is pfUI's own child
+-- frame (tab.backdrop), so colour that instead of the tab itself.
+local function TintTab(tab, bg, border)
+    local target = tab
+    if tab.backdrop and tab.backdrop.SetBackdropColor then
+        target = tab.backdrop
+    end
+    if not target.SetBackdropColor then return end
+    target:SetBackdropColor(bg[1], bg[2], bg[3], 1)
+    if target.SetBackdropBorderColor then
+        target:SetBackdropBorderColor(border[1], border[2], border[3])
+    end
+end
+
 function ui.SelectSubTab(name)
     if not ui.subtabs then return end
     ui.selectedSubTab = name
     for k, tab in pairs(ui.subtabs) do
         if k == name then
-            tab:SetBackdropColor(C.tabOn[1], C.tabOn[2], C.tabOn[3], 1)
-            tab:SetBackdropBorderColor(C.border[1], C.border[2], C.border[3])
+            TintTab(tab, C.tabOn, C.border)
             tab.label:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
         else
-            tab:SetBackdropColor(C.tabOff[1], C.tabOff[2], C.tabOff[3], 1)
-            tab:SetBackdropBorderColor(0.30, 0.26, 0.16)
+            TintTab(tab, C.tabOff, { 0.30, 0.26, 0.16 })
             tab.label:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
         end
     end
@@ -4506,6 +4551,7 @@ function ui.HookAuctionFrame()
             ui.OpenWindow()
         end)
         ui.blizSwapBtn = b
+        if A.skin then A.skin.ApplyExternal() end
     end
 
     ui.ahHooked = true

--- a/ui/skin.lua
+++ b/ui/skin.lua
@@ -1,0 +1,225 @@
+-- Aegis: Exchange
+-- ui/skin.lua
+--
+-- Optional pfUI skin. When pfUI is installed, restyle our window with pfUI's
+-- own backdrop / button / checkbox / scrollbar helpers so Aegis matches the
+-- rest of the UI instead of wearing vanilla tooltip borders.
+--
+-- Design rules for this file:
+--   * It is PURELY cosmetic. Nothing here may change behaviour, and every
+--     pfUI call is wrapped so a pfUI API change can never break the addon --
+--     worst case you keep the default look.
+--   * pfUI's helpers come from pfUI:GetEnvironment() (the same entry point the
+--     pfUI-addonskinner skins use). Each is checked before use.
+--   * Skinning is applied ONCE, after the window is built.
+--
+-- Users of pfUI-addonskinner can also drive this from their skins folder --
+-- see pfui/Aegis_Exchange.lua in this repo; it just calls A.skin.Apply().
+
+local A = AegisExchange
+A.skin = {}
+local skin = A.skin
+
+skin.applied = false
+
+-- pfUI present and exposing its helper environment?
+function skin.Available()
+    return (pfUI and pfUI.GetEnvironment) and true or false
+end
+
+-- Should we skin? pfUI must be present AND the user setting left on.
+function skin.Enabled()
+    if not skin.Available() then return false end
+    if A.db and A.db.Setting and A.db.Setting("pfSkin") == false then
+        return false
+    end
+    return true
+end
+
+-- Fetch pfUI's helpers once. Returns a table of the ones we actually use, each
+-- possibly nil (callers must check).
+local function Env()
+    if skin.env then return skin.env end
+    local ok, env = pcall(function() return pfUI:GetEnvironment() end)
+    if not ok or not env then return nil end
+    skin.env = {
+        CreateBackdrop = env.CreateBackdrop,
+        StripTextures  = env.StripTextures,
+        SkinButton     = env.SkinButton,
+        SkinCheckbox   = env.SkinCheckbox,
+        SkinScrollbar  = env.SkinScrollbar,
+    }
+    return skin.env
+end
+
+-- ---------------------------------------------------------------------------
+-- Small wrappers -- every pfUI call goes through pcall so a missing or changed
+-- helper degrades to "unskinned", never to an error.
+-- ---------------------------------------------------------------------------
+
+local function Backdrop(frame, alpha)
+    local env = Env()
+    if not frame or not env or not env.CreateBackdrop then return end
+    -- Drop our own vanilla backdrop first so we don't end up double-bordered.
+    if frame.SetBackdrop then pcall(function() frame:SetBackdrop(nil) end) end
+    pcall(function() env.CreateBackdrop(frame, nil, nil, alpha) end)
+end
+
+local function Strip(frame)
+    local env = Env()
+    if not frame or not env or not env.StripTextures then return end
+    pcall(function() env.StripTextures(frame, true) end)
+end
+
+local function Button(b)
+    local env = Env()
+    if not b or not env or not env.SkinButton then return end
+    pcall(function() env.SkinButton(b) end)
+end
+
+local function Checkbox(c)
+    local env = Env()
+    if not c or not env or not env.SkinCheckbox then return end
+    pcall(function() env.SkinCheckbox(c) end)
+end
+
+local function Scrollbar(sb)
+    local env = Env()
+    if not sb or not env or not env.SkinScrollbar then return end
+    pcall(function() env.SkinScrollbar(sb) end)
+end
+
+-- ---------------------------------------------------------------------------
+-- Frame walking
+-- ---------------------------------------------------------------------------
+
+-- Children of `frame` as an array (1.12 returns them as multiple values; the
+-- table constructor captures them, which is Lua 5.0 safe).
+local function Children(frame)
+    if not frame or not frame.GetChildren then return {} end
+    local ok, t = pcall(function() return { frame:GetChildren() } end)
+    if not ok or not t then return {} end
+    return t
+end
+
+-- Skin one widget according to what it is. Returns true when handled.
+local function SkinWidget(f)
+    if not f or f.aegisSkinned then return false end
+    local ok, otype = pcall(function() return f:GetObjectType() end)
+    if not ok then return false end
+
+    if otype == "Button" or otype == "CheckButton" then
+        -- pfUI has a dedicated checkbox look; everything else is a button.
+        local isCheck = false
+        if otype == "CheckButton" then isCheck = true end
+        if isCheck then Checkbox(f) else Button(f) end
+        f.aegisSkinned = true
+        return true
+    elseif otype == "EditBox" then
+        Strip(f)
+        Backdrop(f)
+        f.aegisSkinned = true
+        return true
+    elseif otype == "Slider" then
+        Scrollbar(f)
+        f.aegisSkinned = true
+        return true
+    elseif otype == "StatusBar" then
+        Backdrop(f, 0.8)
+        f.aegisSkinned = true
+        return true
+    end
+    return false
+end
+
+-- Walk `frame` and its descendants, skinning what we recognise. `depth` guards
+-- against any pathological nesting.
+local function SkinTree(frame, depth)
+    if not frame or depth > 6 then return end
+    local kids = Children(frame)
+    local i = 1
+    local n = table.getn(kids)
+    while i <= n do
+        local child = kids[i]
+        if child then
+            SkinWidget(child)
+            SkinTree(child, depth + 1)
+        end
+        i = i + 1
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- Apply
+-- ---------------------------------------------------------------------------
+
+-- Restyle the Aegis window (and our buttons on other frames) to match pfUI.
+-- Safe to call repeatedly; only the first full pass does the work.
+function skin.Apply()
+    if not skin.Enabled() then return false end
+    if not Env() then return false end
+    local ui = A.ui
+    if not ui or not ui.frame then return false end
+    if skin.applied then
+        skin.ApplyExternal()   -- late-created buttons on other addons' frames
+        return true
+    end
+
+    -- Main window + the recessed content well.
+    Backdrop(ui.frame, 1)
+    Backdrop(ui.content, 1)
+    if ui.titleBar then Backdrop(ui.titleBar, 1) end
+
+    -- Sub-tab pills. These are custom-drawn Buttons whose colour we manage in
+    -- SelectSubTab, so give them a pfUI backdrop and let our colouring ride on
+    -- top (SelectSubTab re-tints frame.backdrop when present).
+    if ui.subtabs then
+        for _, tab in pairs(ui.subtabs) do
+            Backdrop(tab, 1)
+            tab.aegisSkinned = true   -- keep the generic pass off them
+        end
+    end
+
+    -- Everything else in the window, by widget type.
+    SkinTree(ui.frame, 0)
+
+    -- Overlays are parented to the window but built lazily.
+    if ui.picker then Backdrop(ui.picker, 1); SkinTree(ui.picker, 0) end
+    if ui.vendList then Backdrop(ui.vendList, 1); SkinTree(ui.vendList, 0) end
+
+    skin.applied = true
+    skin.ApplyExternal()
+    return true
+end
+
+-- Our buttons that live on OTHER frames (profession windows, the merchant, the
+-- stock auction house). They appear later than the window, so this runs both
+-- from Apply and whenever one of them is created.
+function skin.ApplyExternal()
+    if not skin.Enabled() then return end
+    local names = {
+        "AegisExchangeAddTradeSkillButton",
+        "AegisExchangeAddCraftButton",
+        "AegisExchangeMerchantSellButton",
+        "AegisExchangeSwapButton",
+    }
+    local i = 1
+    while i <= table.getn(names) do
+        local b = getglobal(names[i])
+        if b and not b.aegisSkinned then
+            Button(b)
+            b.aegisSkinned = true
+        end
+        i = i + 1
+    end
+end
+
+-- Re-skin the lazily-built overlays the first time they appear.
+function skin.ApplyOverlay(frame)
+    if not skin.Enabled() or not frame then return end
+    if frame.aegisSkinnedOverlay then return end
+    if not Env() then return end
+    Backdrop(frame, 1)
+    SkinTree(frame, 0)
+    frame.aegisSkinnedOverlay = true
+end


### PR DESCRIPTION
## Summary

Aegis now **skins itself to match pfUI**, and the README documents the vendor features.

> ⚠️ **This adds a new file (`ui/skin.lua`), so it needs a FULL client restart — a `/reload` won't pick it up.**

### The pfUI skin
Reading the addonskinner sources you shared, the important detail is that its skins live in *its* `skins/` folder and simply **call functions**. Since Aegis is our own addon, it can skin itself directly — no dependency on addonskinner at all.

When pfUI is installed, Aegis restyles with **pfUI's own helpers** (`CreateBackdrop`, `StripTextures`, `SkinButton`, `SkinCheckbox`, `SkinScrollbar`) fetched via `pfUI:GetEnvironment()` — the same entry point the addonskinner skins use.

- Window, content well, title bar and sub-tabs are skinned explicitly; everything else via a **depth-limited walk of the frame tree** that dispatches on widget type — so new widgets get skinned automatically instead of needing a hand-maintained list.
- Our buttons on *other* frames (profession windows, merchant, the stock AH) are skinned as they're created; the lazily-built picker and vendor-list overlays when first shown.
- Sub-tab tinting now targets pfUI's backdrop child when present, so the selected-tab highlight still works under the skin.
- New **"Match pfUI's look"** setting on the Aegis tab (on by default, greyed out without pfUI, takes a `/reload`).

**Safety:** the skin is purely cosmetic. Every pfUI call is `pcall`-wrapped and each helper checked before use, so a pfUI API change degrades to the default look and can never break the addon. The harness asserts this directly by feeding it a **deliberately broken pfUI environment**.

### For pfUI-addonskinner users
`pfui/Aegis_Exchange.lua` is an optional drop-in (copy to addonskinner's `skins/`, add one `.toc` line). It just calls `A.skin.Apply()`, so both paths render identically and can't drift. Not loaded by our `.toc`.

### README
- New **🏪 Vendor list** section: what it compares, the mark-items workflow, the merchant **"Aegis: sell N marked"** button, and the caveat that vendor prices are learned by hovering items at a merchant.
- **Sell** section gains the History panel and the post-scan Post/Skip queue.
- New **"Using pfUI?"** section with a collapsible addonskinner walkthrough.

### Testing
Harness loads `skin.lua`, then simulates pfUI being installed: the skin applies, the window still builds and switches tabs, a **failing** pfUI environment degrades safely, and the setting disables it. The no-pfUI no-op path is asserted too. All checks pass.

> Version **0.20.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_