### PR TITLE
Polish the README, add the Discord link, and start a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,208 @@
+# Changelog
+
+All notable changes to **Aegis: Exchange**.
+
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
+The version here matches `## Version` in `Aegis_Exchange.toc` and the number
+printed in the window title bar — quote it in bug reports.
+
+> ⚠️ Releases marked **restart** add a new `.lua` file. WoW 1.12 reads the file
+> list at startup, so `/reload` won't pick them up — you need to fully restart
+> the client. Everything else is `/reload`-safe.
+
+---
+
+## [0.20.2]
+
+### Fixed
+- **pfUI: header row alignment.** The title strip now hugs the frame under the
+  skin, and the close button anchors to the *strip* (centred on it) rather than
+  the frame corner — so the X, version text and **Blizzard UI** button stay
+  locked together. Our default offsets were tuned for vanilla's thick border;
+  pfUI's is a hairline, so everything drifted.
+- **pfUI: merchant button alignment.** The **Aegis: sell N marked** button moved
+  into the tab row, right of Merchant / Buyback. It anchors to the *tabs*, which
+  move with the window when pfUI restyles it, so it lines up in both UIs.
+
+## [0.20.1]
+
+### Added
+- **Every column sorts.** Buy and Crafting gained **Item** (alphabetical) and
+  **Ct**; the Sell tab's listing table gained sorting on all five of its columns.
+- **Auto-pricing on the Sell tab.** Selecting an item fills the buyout from its
+  lowest competing listing with your undercut rule applied. A price you typed
+  yourself survives a re-scan of the same item.
+
+### Fixed
+- **pfUI: close button** rendered as an oversized empty box — pfUI's generic
+  button skinner strips the X. Now routed to its close-button helper.
+- **pfUI: sort headers** were skinned into boxes that visibly overlapped. They
+  now opt out of skinning and stay bare clickable text.
+- `Blizzard_AuctionUI.lua:836: attempt to perform arithmetic on field 'page'`.
+  Blizzard seeds `AuctionFrameAuctions.page` in its own `OnShow`, but we replace
+  that window — so any owned-auction update we caused hit their handler with a
+  nil field. Now seeded when we hook the AH.
+
+## [0.20.0] — restart
+
+### Added
+- **pfUI skin.** With pfUI installed, Aegis restyles itself using pfUI's own
+  backdrop / button / checkbox / scrollbar helpers. Toggle with **Match pfUI's
+  look** on the Aegis tab. Purely cosmetic and fully guarded — if pfUI's API
+  changes, the worst case is the default look.
+- `pfui/Aegis_Exchange.lua`, an optional drop-in for
+  [pfUI-addonskinner](https://github.com/mrrosh/pfUI-addonskinner) users.
+
+## [0.19.1]
+
+### Fixed
+- Merchant button no longer lands on pfUI's Merchant / Buyback tabs.
+
+## [0.19.0]
+
+### Added
+- **Sell vendor-marked items at a merchant.** Tick items on the Vendor list
+  (or *Mark all*); at any merchant an **Aegis: sell N marked** button appears,
+  confirms what's about to go, sells the lot, and logs the gold to History.
+- The Sell tab's per-item scan now shows the same live
+  `Page 3 / 6 • ~12s • 16.6/s` line as the Aegis strip.
+
+## [0.18.0]
+
+### Added
+- **Vendor list** — bag items worth more at a merchant than on the AH, comparing
+  vendor price against the best AH price *after the 5% cut*, sorted by gain.
+- **History panel on the Sell tab** — what your scans say the item is worth
+  (median, range, days of data) next to what it has actually sold for.
+- **Post-scan sell queue** — after a bag scan the first item is slotted
+  automatically; **Post** or **Skip** walks to the next.
+
+## [0.17.0]
+
+### Added
+- **History tab.** Sales are logged straight from your mailbox (every
+  "Auction successful" mail, deduped so reopening never double-counts);
+  purchases are logged when you buy. Shows **Income · Spent · Net** over
+  24h / 7d / 30d / all time.
+
+## [0.16.1]
+
+### Fixed
+- Hovering the sell slot could throw a Lua error. Tooltip hooks now only wrap
+  methods that actually exist, and the slot uses `SetAuctionSellItem`.
+
+## [0.16.0]
+
+### Added
+- **Stop** button for scans — a paused scan no longer blocks browsing, so you
+  can pause, check a price, then resume or stop.
+- **Undercut by a flat amount** as well as a percentage (1 copper now works).
+- Hover tooltips on the Sell tab's bag list and sell slot.
+- Item icons beside names on the Buy and Auctions tabs.
+- Bid-only auctions show the current bid instead of just "bid only".
+
+### Changed
+- The header bar now extends cleanly to the close button.
+
+## [0.15.1]
+
+### Removed
+- The window portrait / crest (revisiting the branding later).
+
+## [0.15.0]
+
+### Added
+- **Auctions tab** — your active auctions with time left, bid state, an
+  **undercut flag** (green = still cheapest, red = someone's under you), and a
+  per-row Cancel. This filled the last placeholder tab.
+
+## [0.14.0]
+
+### Added
+- Aegis crest as a window portrait. *(Removed again in 0.15.1.)*
+
+## [0.13.0]
+
+### Added
+- **Aegis tab** (was Scan) with settings: default post duration, undercut rule,
+  default sell price, tooltip lines, profit line, and price-data management.
+
+### Changed
+- **Add to Aegis** moved to the profession window's bottom-right, below the
+  profit text — clear of both the stock UI and pfUI.
+
+## [0.12.1]
+
+### Fixed
+- Profit line no longer overlaps the skill progress bar; Crafting's **Search**
+  button no longer covers the **Item** column header.
+
+## [0.12.0]
+
+### Added
+- **Live profit line on profession windows** — reads saved prices, so it works
+  with the auction house closed.
+
+## [0.11.0]
+
+### Added
+- **Crafting profit/loss estimate**: reagent cost vs. what the item sells for,
+  minus the 5% cut.
+
+### Changed
+- **Ordinary searches now feed the price database**, not just full scans — so
+  `% mkt` and profit estimates work without scanning everything.
+
+## [0.10.0]
+
+### Added
+- **Crafting tab** and the **Add to Aegis** button on profession windows:
+  capture a recipe, then shop each reagent like any other item.
+
+## [0.9.x]
+
+### Added
+- **Buy tab**: search, sort, buy and bid; shopping lists and recent searches.
+- Click a listing to adopt its price; max-price filter; sortable columns.
+
+## [0.8.0]
+
+### Added
+- Multi-stack posting — "3 stacks of 20" in one go.
+
+## [0.7.x]
+
+### Added
+- Sell tab bag browser, per-item live scan, and a listings table.
+- Soulbound and non-postable items filtered out.
+
+## [0.6.0]
+
+### Added
+- **Sell tab** — post from the sell slot with Aegis price context.
+
+## [0.5.0]
+
+### Added
+- Scan as its own tab; two-way swap with the Blizzard auction house.
+
+## [0.4.0]
+
+### Fixed
+- The real scan killer: hiding the Blizzard AH is now deferred past
+  `AuctionFrame_Show`'s visibility guard, which was silently ending the session
+  and leaving scans stuck on "Requesting first page…".
+
+## [0.1.0] – [0.3.0]
+
+### Added
+- Standalone Aegis window replacing the auction house frame.
+- Page-by-page auction scanner with throttling, pause / resume, and a targeted
+  class → subclass category picker.
+- Price database — daily minimum buyouts, market value as a time-weighted
+  median over ~11 days.
+- Price lines on item tooltips, including vendor price.
+
+---
+
+[0.20.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Aegis: Exchange
 
-**A clean, "fast" auction house for Turtle WoW.**
+**A clean, fast auction house for Turtle WoW.**
+
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/3wTfRU8V9Z)
+[![Client](https://img.shields.io/badge/client-WoW%201.12%20(vanilla)-c79c6e?style=flat-square)](https://turtle-wow.org)
+[![pfUI](https://img.shields.io/badge/pfUI-skin%20included-33ffcc?style=flat-square)](#using-pfui)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 
 The stock 1.12 auction house is three text boxes and a prayer. Aegis replaces it
 with a window that actually knows what things are worth — what you should charge,
@@ -9,6 +14,21 @@ made this week.
 
 > Built for **Turtle WoW 1.18.1**, which runs the original **WoW 1.12 (vanilla)**
 > client on **Lua 5.0**. Not Classic. Not retail. Real vanilla.
+
+**[💬 Join the Discord](https://discord.gg/3wTfRU8V9Z)** for help, bug reports,
+and feature ideas.
+
+---
+
+## Contents
+
+- [What it does](#what-it-does) — the six tabs
+- [Using pfUI?](#using-pfui)
+- [Install](#install)
+- [Using it](#using-it)
+- [A few honest notes](#a-few-honest-notes)
+- [Under the hood](#under-the-hood)
+- [Contributing](#contributing)
 
 ---
 
@@ -183,11 +203,30 @@ and the reasons behind them, most of which were learned the hard way.
 
 ---
 
+## Something broken?
+
+1. Check the **version** in the window's title bar (`v0.20.2`) — quote it.
+2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
+3. Tell us on **[Discord](https://discord.gg/3wTfRU8V9Z)** or open an
+   [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots
+   help enormously, especially for anything layout-related.
+
+Recent changes are in [CHANGELOG.md](CHANGELOG.md).
+
+---
+
 ## Contributing
 
-PRs welcome. Two requests: keep it inside the 1.12 rules in `CLAUDE.md`, and bump
-the version in both `core/init.lua` and the `.toc` so in-game bug reports say
-which build they came from.
+PRs welcome — come say hi on **[Discord](https://discord.gg/3wTfRU8V9Z)** first
+if you're planning something big.
+
+Three requests:
+
+1. Keep inside the 1.12 / Lua 5.0 rules in [`CLAUDE.md`](CLAUDE.md) — they're
+   there because breaking them fails at *runtime*, not at load.
+2. Bump the version in **both** `core/init.lua` and the `.toc`, so in-game bug
+   reports say which build they came from.
+3. Add a line to [`CHANGELOG.md`](CHANGELOG.md).
 
 ## License
 
@@ -195,4 +234,10 @@ MIT — see [LICENSE](LICENSE).
 
 ---
 
+<div align="center">
+
+**[💬 Discord](https://discord.gg/3wTfRU8V9Z)** · **[📜 Changelog](CHANGELOG.md)** · **[🐛 Issues](https://github.com/Torchlite-bit/Aegis_Exchange/issues)**
+
 *Aegis: Exchange is part of the Aegis addon series. Happy flipping.* ⚔️
+
+</div>


### PR DESCRIPTION
## Summary

### README
- **Discord link** in three places people actually look: a badge at the top, a line under the intro, and a footer row (Discord · Changelog · Issues).
- **Badges** for the client, the pfUI skin, and the licence.
- **Table of contents** — the page had grown past the point where you could scan it.
- **New "Something broken?" section**: quote the version from the title bar, `/aex debug` for scan trouble, then Discord or an issue. Asks for screenshots, since nearly every layout bug this project has had was diagnosed from one.
- **Contributing** now asks for a changelog line, and explains *why* the 1.12 rules matter — they fail at runtime, not at load, which is exactly what makes them easy to break.

All internal anchors and file links verified to resolve.

### CHANGELOG.md
Reconstructed from the git history — newest first, grouped **Added / Changed / Fixed / Removed**, from `0.1.0` through `0.20.2`.

Two things worth noting in it:
- Releases that add a `.lua` file are marked **restart**, because those need a full client restart rather than a `/reload` — the single most common "why isn't my change showing up" trap in this project.
- The header explains that the version shown matches the `.toc` and the title bar, so bug reports can quote it.

Going forward I'll add an entry with each version bump, and the Contributing section now asks the same of others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_