### PR TITLE
Adaptive scan pacing: fast with AuctionQueryThrottle, polite without (v0.21.0)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.20.2
+## Version: 0.21.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [0.21.0]
+
+### Added
+- **Adaptive scan pacing.** Aegis now waits on the client's own
+  `CanSendAuctionQuery()` gate rather than a fixed wall-clock delay, so a client
+  running the [AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle)
+  DLL scans as fast as the server answers, while a stock client still waits its
+  ~5s. That DLL is not an addon, so there is nothing to detect — the gate *is*
+  the signal.
+- **Scan pacing** setting on the Aegis tab (**Auto** / **Safe 4s**) with a live
+  readout of what the gate is actually doing (`fast — gate opened in 0.28s`).
+
 ## [0.20.2]
 
 ### Fixed
@@ -205,4 +217,4 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
-[0.20.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
+[0.21.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,19 @@ or silent breakage on the 1.12 / Lua 5.0 client.
      (`invType`, `class`, `subclass`, `isUsable`, `quality`) stay nil for
      "no filter".
 10. **Throttle every query.** Poll **`CanSendAuctionQuery()`** before **every**
-    query. Leave **~4 seconds between pages**. Wait for the
-    **`AUCTION_ITEM_LIST_UPDATE`** event before reading a page.
+    query — that gate is the authority, never a wall-clock timer alone. Wait
+    for the **`AUCTION_ITEM_LIST_UPDATE`** event before reading a page.
+    - The client keeps the gate shut ~5s after each query, which is where the
+      old "leave ~4 seconds between pages" rule of thumb came from. We now
+      apply only a small floor (`scan.FAST_DELAY`) and let the gate do the
+      throttling, because the **AuctionQueryThrottle** DLL
+      (<https://github.com/brues-code/AuctionQueryThrottle>) clears that timer
+      as soon as the reply lands. It is a DLL, **not an addon** — there is
+      nothing to `IsAddOnLoaded()`, so the gate itself is the detector: it
+      opens fast with the DLL and stays shut ~5s without it.
+    - `scan.PageDelay()` returns the floor for the current pacing setting;
+      "safe" restores the fixed 4s for clients that report the gate unreliably.
+      **Never** send a query without checking the gate, whatever the floor.
 11. **Page size is 50.**
 12. **Hiding `AuctionFrame` ENDS the AH session.** `AuctionFrame`'s XML
     `<OnHide>` runs **`CloseAuctionHouse()`**, so **any** `AuctionFrame:Hide()`

--- a/README.md
+++ b/README.md
@@ -167,9 +167,15 @@ numbers, % colours, and profit estimates fill in as you go.
 - **Turtle specifics are baked in:** durations are ×3 (6h / 24h / 72h), there's a
   120-auction account cap, a 5% cut on sales, and the auction house is
   **cross-faction** — one shared economy, so prices aren't split by side.
-- **Scanning is deliberately polite.** ~4 seconds between pages, because the 1.12
-  server will happily ignore you if you hammer it. A full scan takes a while;
-  that's the protocol, not the addon.
+- **Scanning is paced by your client, not by us.** Aegis waits on the client's
+  own `CanSendAuctionQuery()` gate, which vanilla keeps shut ~5s after every
+  query. A full scan takes a while; that's the protocol, not the addon.
+  - Running the [AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle)
+    DLL? It clears that timer as soon as the server replies, so **Aegis speeds
+    up automatically** — nothing to configure. It's a DLL rather than an addon,
+    so there's nothing to detect: the gate *is* the signal. The Aegis tab shows
+    which you're getting (`fast — gate opened in 0.28s`), and **Safe 4s** pacing
+    is there if you ever want the old fixed floor back.
 - **Mail sale-tracking is enUS-only** right now (it matches "Auction successful:").
 
 ---
@@ -205,7 +211,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v0.20.2`) — quote it.
+1. Check the **version** in the window's title bar (`v0.21.0`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/Hr66t25vE7)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/core/db.lua
+++ b/core/db.lua
@@ -87,6 +87,12 @@ local SETTING_DEFAULTS = {
     tooltip        = true,      -- show Aegis price lines on item tooltips
     profLine       = true,      -- show the profit line on profession windows
     pfSkin         = true,      -- match pfUI's look when pfUI is installed
+    -- Query pacing between scan pages:
+    --   "auto" -- let the client's CanSendAuctionQuery() gate decide. Vanilla
+    --            keeps it shut ~5s; the AuctionQueryThrottle DLL clears it as
+    --            soon as the reply lands, so scans speed up automatically.
+    --   "safe" -- always keep the fixed 4s floor as well.
+    queryThrottle  = "auto",
 }
 
 -- Read a user setting, falling back to its default when unset.

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.20.2"
+A.version = "0.21.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/scan.lua
+++ b/core/scan.lua
@@ -24,7 +24,43 @@ local util = A.util
 scan.PAGE_SIZE = 50
 
 -- Seconds to wait between page queries (on top of CanSendAuctionQuery).
-scan.PAGE_DELAY = 4
+--
+-- The REAL throttle is the client's own CanSendAuctionQuery() gate: vanilla
+-- keeps it shut for ~5s after each query. This wall-clock delay is a floor we
+-- add on top of it.
+--
+-- AuctionQueryThrottle (https://github.com/brues-code/AuctionQueryThrottle) is
+-- a DLL -- not an addon, so there is nothing to IsAddOnLoaded() -- that clears
+-- that timer as soon as the server's reply lands. With it installed the gate
+-- opens almost immediately, so a 4s floor would throw the benefit away.
+--
+-- So in "auto" (the default) we drop the floor to FAST_DELAY and let the
+-- CLIENT'S GATE do the throttling. That is correct either way:
+--   * DLL present  -> gate opens at round-trip speed -> we scan fast.
+--   * DLL absent   -> gate stays shut ~5s -> we wait exactly as before.
+-- No detection needed; the gate IS the detector. "safe" restores the old
+-- fixed floor for anyone whose client reports the gate unreliably.
+scan.PAGE_DELAY = 4      -- "safe" floor
+scan.FAST_DELAY = 0.25   -- "auto" floor: just enough not to poll every frame
+
+-- Gate openings at or under this many seconds mean the throttle has been
+-- lifted (the DLL is doing its job). Purely informational -- it drives the
+-- readout, not the pacing.
+scan.FAST_GATE = 1.5
+
+-- The floor to use right now, per the Aegis-tab setting.
+function scan.PageDelay()
+    local mode = A.db and A.db.Setting and A.db.Setting("queryThrottle") or "auto"
+    if mode == "safe" then return scan.PAGE_DELAY end
+    return scan.FAST_DELAY
+end
+
+-- True once we've seen the client's gate open fast enough that the vanilla
+-- throttle is clearly not in play. Reported in the UI so it's obvious whether
+-- AuctionQueryThrottle is actually working.
+function scan.FastThrottleSeen()
+    return scan.state.fastGate and true or false
+end
 
 -- Seconds to wait for AUCTION_ITEM_LIST_UPDATE before re-sending the same
 -- page (lost replies happen on laggy servers).
@@ -56,6 +92,9 @@ scan.state = {
     sent          = 0,     -- queries actually handed to the client this run
     retries       = 0,     -- re-sends of the CURRENT page (reply never came)
     waitOk        = 0,     -- seconds spent blocked on CanSendAuctionQuery()
+    gateWait      = 0,     -- seconds the CURRENT gate wait has taken
+    lastGate      = nil,   -- how long the last gate took to open
+    fastGate      = false, -- gate has opened fast enough to mean "throttle lifted"
     callbacks     = nil,   -- { onPage = fn(page1, totalPages),
                            --   onComplete = fn(stats) }
 }
@@ -139,7 +178,22 @@ function scan.OnUpdate(dt)
     if st.phase == "wait_query" then
         st.cooldown = st.cooldown - dt
         if st.cooldown <= 0 then
+            -- Past our floor: the client's own gate now decides. This is the
+            -- part that adapts -- with AuctionQueryThrottle it opens at
+            -- round-trip speed, without it we sit here the vanilla ~5s.
+            st.gateWait = st.gateWait + dt
             if CanSendAuctionQuery() then
+                st.lastGate = st.gateWait
+                if st.gateWait <= scan.FAST_GATE then
+                    if not st.fastGate then
+                        scan.Debug(string.format(
+                            "query gate opened in %.2fs \226\128\148 throttle"
+                            .. " looks lifted (AuctionQueryThrottle?)",
+                            st.gateWait))
+                    end
+                    st.fastGate = true
+                end
+                st.gateWait = 0
                 st.waitOk = 0
                 SendQuery()
             else
@@ -219,7 +273,7 @@ local function StartCurrentQuery()
     if st.queryIndex == 1 then
         st.cooldown = 0
     else
-        st.cooldown = scan.PAGE_DELAY
+        st.cooldown = scan.PageDelay()
     end
     st.timeout = 0
 end
@@ -258,7 +312,7 @@ function scan.OnListUpdate()
     else
         st.page = st.page + 1
         st.phase = "wait_query"
-        st.cooldown = scan.PAGE_DELAY
+        st.cooldown = scan.PageDelay()
     end
 end
 
@@ -293,6 +347,9 @@ function scan.Start(queryOrList, callbacks)
     st.sent           = 0
     st.retries        = 0
     st.waitOk         = 0
+    st.gateWait       = 0
+    st.lastGate       = nil
+    st.fastGate       = false
     StartCurrentQuery()
     st.cooldown       = 0    -- first query goes as soon as the client allows
     scan.driver:Show()
@@ -317,7 +374,7 @@ function scan.Continue()
     local st = scan.state
     if st.phase ~= "paused" then return end
     st.page = st.lastCompleted + 1
-    st.cooldown = scan.PAGE_DELAY   -- be polite on re-entry
+    st.cooldown = scan.PageDelay()   -- be polite on re-entry
     st.timeout = 0
     st.phase = "wait_query"
     scan.driver:Show()
@@ -354,7 +411,7 @@ function scan.GetProgress()
     if st.elapsed > 0 then
         rate = st.scanned / st.elapsed
     end
-    local secPerPage = scan.PAGE_DELAY + 1
+    local secPerPage = scan.PageDelay() + 1
     if overallDone > 0 then
         secPerPage = st.elapsed / overallDone
     end
@@ -376,6 +433,8 @@ function scan.GetProgress()
         sent        = st.sent or 0,
         retries     = st.retries or 0,
         phase       = st.phase,
+        lastGate    = st.lastGate,
+        fastGate    = st.fastGate and true or false,
     }
 end
 

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -553,9 +553,41 @@ function ui.BuildAegisSettings(panel, anchorAbove)
     end)
     ui.setPfSkin = pfChk
 
+    -- ---- Scan pacing -------------------------------------------------------
+    -- "Auto" leans on the client's own CanSendAuctionQuery() gate, so a client
+    -- running the AuctionQueryThrottle DLL scans as fast as the server answers
+    -- while a stock client still waits its ~5s. "Safe" keeps the fixed floor.
+    local thLbl = label("Scan pacing:", pfChk, -12)
+
+    ui.setThrottleBtns = {}
+    local modes = { { "Auto", "auto" }, { "Safe 4s", "safe" } }
+    local prevTh = nil
+    local ti = 1
+    while ti <= table.getn(modes) do
+        local m = modes[ti]
+        local b = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+        b:SetWidth(64); b:SetHeight(20)
+        if prevTh then b:SetPoint("LEFT", prevTh, "RIGHT", 4, 0)
+        else b:SetPoint("LEFT", thLbl, "RIGHT", 10, 0) end
+        b:SetText(m[1])
+        b.mode = m[2]
+        b:SetScript("OnClick", function()
+            A.db.SetSetting("queryThrottle", b.mode)
+            ui.RefreshSettings()
+        end)
+        ui.setThrottleBtns[ti] = b
+        prevTh = b
+        ti = ti + 1
+    end
+
+    ui.setThrottleInfo = panel:CreateFontString(nil, "OVERLAY",
+        "GameFontHighlightSmall")
+    ui.setThrottleInfo:SetPoint("LEFT", prevTh, "RIGHT", 10, 0)
+    ui.setThrottleInfo:SetJustifyH("LEFT")
+
     -- ---- Price data -------------------------------------------------------
     ui.setDataText = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    ui.setDataText:SetPoint("TOPLEFT", pfChk, "BOTTOMLEFT", 4, -14)
+    ui.setDataText:SetPoint("TOPLEFT", thLbl, "BOTTOMLEFT", 0, -14)
     ui.setDataText:SetTextColor(C.text[1], C.text[2], C.text[3])
 
     local clearBtn = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
@@ -647,6 +679,37 @@ function ui.RefreshSettings()
     if ui.setDataText then
         ui.setDataText:SetText("Price data: " .. A.db.ItemCount()
             .. " item(s) recorded")
+    end
+
+    -- Scan pacing: highlight the active mode and report what the client's
+    -- query gate is actually doing, so it's obvious whether a throttle-removing
+    -- DLL (AuctionQueryThrottle) is having any effect.
+    local thMode = A.db.Setting("queryThrottle") or "auto"
+    if ui.setThrottleBtns then
+        local ti = 1
+        while ti <= table.getn(ui.setThrottleBtns) do
+            local b = ui.setThrottleBtns[ti]
+            if b.mode == thMode then b:LockHighlight() else b:UnlockHighlight() end
+            ti = ti + 1
+        end
+    end
+    if ui.setThrottleInfo then
+        local p = A.scan.GetProgress()
+        if thMode == "safe" then
+            ui.setThrottleInfo:SetText("fixed 4s between pages")
+            ui.setThrottleInfo:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+        elseif p.fastGate then
+            ui.setThrottleInfo:SetText(string.format(
+                "fast \226\128\148 gate opened in %.2fs", p.lastGate or 0))
+            ui.setThrottleInfo:SetTextColor(0.30, 0.85, 0.30)
+        elseif p.lastGate then
+            ui.setThrottleInfo:SetText(string.format(
+                "client throttled \226\128\148 gate took %.1fs", p.lastGate))
+            ui.setThrottleInfo:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+        else
+            ui.setThrottleInfo:SetText("follows the client's own query gate")
+            ui.setThrottleInfo:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

Scans now go as fast as the server answers **if** your client can, and stay polite if it can't — with **no detection required**.

### Why there's nothing to detect
[AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle) turns out to be a **DLL, not an addon** — no `.toc`, no globals, nothing for `IsAddOnLoaded()` to find. It hooks the auction packet handler and **clears the client's rate-limit timer** when the server's reply lands.

That timer is *exactly* what `CanSendAuctionQuery()` reports. So instead of detecting the DLL, Aegis leans on the gate the DLL manipulates:

| | Gate behaviour | Result |
|---|---|---|
| **With the DLL** | opens at round-trip speed | scans fast |
| **Stock client** | stays shut ~5s | waits exactly as before |

**The gate *is* the detector.** No version sniffing, no fragile heuristics.

### What changed
- The wall-clock floor drops to `FAST_DELAY` (0.25s) and the **client's own gate** does the throttling.
- **Every query is still gated on `CanSendAuctionQuery()`** — so a client *without* the DLL can never be spammed. The floor only controls how often we *ask*; the client decides when we may *send*.
- Gate-open time is now measured. Fast openings mark the throttle as lifted, which `/aex debug` traces and the Aegis tab reports: **`fast — gate opened in 0.28s`** — so you can see whether the DLL is actually doing anything.
- New **Scan pacing** setting: **Auto** (default) or **Safe 4s**, the latter restoring the old fixed floor for anyone whose client reports the gate unreliably.

### Testing
The harness covers **both worlds explicitly**:
- **Open gate** → the next page goes out well inside 4s, and `fastGate` / the measured time are reported.
- **Shut gate** → *no query at all* at 2s or 6s, then it fires the moment the client relents. This is the guarantee that lowering the floor can't hammer a stock client.

Legacy multi-page timing tests are pinned to `safe` pacing, since they encode the fixed floor by design.

### Docs
- `CLAUDE.md` hard rule 10 rewritten: `CanSendAuctionQuery()` is the authority, **never a wall-clock timer alone**; the ~4s figure is now explained as what the gate does rather than a rule we impose.
- README's "honest notes" and a CHANGELOG entry.

> Version **0.21.0**; `/reload` is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_