### PR TITLE
Cut the auto-pacing floor to a frame; report gate vs server time; README badges (v0.21.1)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.21.0
+## Version: 0.21.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [0.21.1]
+
+### Changed
+- **Auto pacing is now genuinely minimal.** Our own floor between pages dropped
+  from 0.25s to 0.05s — at 0.25s a 60-page scan spent 15s waiting on *us*
+  rather than the server. The client's gate is still what actually throttles.
+- The scan readout now splits the per-page cost into **gate** vs **server**
+  (`fast — gate 0.02s, server 0.61s`), so a slow scan can be blamed correctly.
+  Realm-to-realm differences show up here as server time, not gate time.
+
 ## [0.21.0]
 
 ### Added
@@ -217,4 +227,4 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
-[0.21.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
+[0.21.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,24 @@ are done in practice — **imitate the approach, do not copy code blindly**:
 
 ---
 
+---
+
+## README / CHANGELOG upkeep
+
+- **The badge block at the top of `README.md` is maintained by the project
+  owner.** It is grouped deliberately — Discord, then the 1.18.1 servers (Octo
+  WoW / Capy WoW), then **Required** loaders (SuperWoW, Nampower, UnitXP_SP3),
+  then **Recommended** (ClassicAPI, SCRM, AuctionQueryThrottle, pfUI). Keep that
+  grouping and the shields.io style (`flat-square`, `labelColor=555`) when
+  adding to it; do not reorder or restyle it unasked.
+- **One Discord invite, used everywhere.** It appears in the badge, the intro
+  line, "Something broken?", Contributing and the footer — change all of them
+  together or none.
+- Every version bump gets a `CHANGELOG.md` entry. Mark a release **restart**
+  when it adds a new `.lua` file to the `.toc`.
+
+---
+
 ## Quick self-check before committing Lua
 
 - [ ] No `string.match` / `string.gmatch` / `:match()` — used `string.find` /

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
 # Aegis: Exchange
 
-**A clean, fast auction house for Turtle WoW.**
+**A clean, fast auction house for vanilla WoW (1.12).**
 
-[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/Hr66t25vE7)
-[![Client](https://img.shields.io/badge/client-WoW%201.12%20(vanilla)-c79c6e?style=flat-square)](https://turtle-wow.org)
-[![pfUI](https://img.shields.io/badge/pfUI-skin%20included-33ffcc?style=flat-square)](#using-pfui)
-[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/hsgPTNkSX)
+
+[![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-4c1?style=flat-square&labelColor=555)](https://octowow.st/)
+[![Capy WoW](https://img.shields.io/badge/Capy%20WoW-1.18.1-4c1?style=flat-square&labelColor=555)](https://capycraft.io/)
+
+[![SuperWoW](https://img.shields.io/badge/SuperWoW-Required-8A2BE2?style=flat-square&labelColor=555)](https://github.com/balakethelock/SuperWoW)
+[![Nampower](https://img.shields.io/badge/Nampower-Required-8A2BE2?style=flat-square&labelColor=555)](https://github.com/brues-code/nampower)
+[![UnitXP_SP3](https://img.shields.io/badge/UnitXP__SP3-Required-8A2BE2?style=flat-square&labelColor=555)](https://codeberg.org/konaka/UnitXP_SP3)
+
+[![ClassicAPI](https://img.shields.io/badge/ClassicAPI-Recommended-dfb317?style=flat-square&labelColor=555)](https://github.com/brues-code/ClassicAPI)
+[![SCRM](https://img.shields.io/badge/SCRM-Recommended-dfb317?style=flat-square&labelColor=555)](https://github.com/brues-code/SuperCleveRoidMacros)
+[![AuctionQueryThrottle](https://img.shields.io/badge/AuctionQueryThrottle-Recommended-dfb317?style=flat-square&labelColor=555)](https://github.com/brues-code/AuctionQueryThrottle)
+[![pfUI](https://img.shields.io/badge/pfUI-skin%20included-33ffcc?style=flat-square&labelColor=555)](#using-pfui)
 
 The stock 1.12 auction house is three text boxes and a prayer. Aegis replaces it
 with a window that actually knows what things are worth — what you should charge,
 what you should pay, whether that recipe is worth crafting, and how much gold you
 made this week.
 
-> Built for **Turtle WoW 1.18.1**, which runs the original **WoW 1.12 (vanilla)**
-> client on **Lua 5.0**. Not Classic. Not retail. Real vanilla.
+> Built for **1.18.1** servers (Octo WoW, Capy WoW, Turtle WoW), which run the
+> original **WoW 1.12 (vanilla)** client on **Lua 5.0**. Not Classic. Not retail.
+> Real vanilla.
 
-**[💬 Join the Discord](https://discord.gg/Hr66t25vE7)** for help, bug reports,
+**[💬 Join the Discord](https://discord.gg/hsgPTNkSX)** for help, bug reports,
 and feature ideas.
 
 ---
@@ -211,9 +221,9 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v0.21.0`) — quote it.
+1. Check the **version** in the window's title bar (`v0.21.1`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
-3. Tell us on **[Discord](https://discord.gg/Hr66t25vE7)** or open an
+3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots
    help enormously, especially for anything layout-related.
 
@@ -223,7 +233,7 @@ Recent changes are in [CHANGELOG.md](CHANGELOG.md).
 
 ## Contributing
 
-PRs welcome — come say hi on **[Discord](https://discord.gg/Hr66t25vE7)** first
+PRs welcome — come say hi on **[Discord](https://discord.gg/hsgPTNkSX)** first
 if you're planning something big.
 
 Three requests:
@@ -242,7 +252,7 @@ MIT — see [LICENSE](LICENSE).
 
 <div align="center">
 
-**[💬 Discord](https://discord.gg/Hr66t25vE7)** · **[📜 Changelog](CHANGELOG.md)** · **[🐛 Issues](https://github.com/Torchlite-bit/Aegis_Exchange/issues)**
+**[💬 Discord](https://discord.gg/hsgPTNkSX)** · **[📜 Changelog](CHANGELOG.md)** · **[🐛 Issues](https://github.com/Torchlite-bit/Aegis_Exchange/issues)**
 
 *Aegis: Exchange is part of the Aegis addon series. Happy flipping.* ⚔️
 

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.21.0"
+A.version = "0.21.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/scan.lua
+++ b/core/scan.lua
@@ -41,7 +41,10 @@ scan.PAGE_SIZE = 50
 -- No detection needed; the gate IS the detector. "safe" restores the old
 -- fixed floor for anyone whose client reports the gate unreliably.
 scan.PAGE_DELAY = 4      -- "safe" floor
-scan.FAST_DELAY = 0.25   -- "auto" floor: just enough not to poll every frame
+-- "auto" floor. Deliberately tiny: the CLIENT'S GATE is the real throttle, so
+-- this only stops us re-testing it every single frame. It is per PAGE, so keep
+-- it small -- at 0.25s a 60-page scan spent 15s doing nothing but waiting on us.
+scan.FAST_DELAY = 0.05
 
 -- Gate openings at or under this many seconds mean the throttle has been
 -- lifted (the DLL is doing its job). Purely informational -- it drives the
@@ -94,6 +97,8 @@ scan.state = {
     waitOk        = 0,     -- seconds spent blocked on CanSendAuctionQuery()
     gateWait      = 0,     -- seconds the CURRENT gate wait has taken
     lastGate      = nil,   -- how long the last gate took to open
+    sentAt        = nil,   -- st.elapsed when the current query went out
+    lastReply     = nil,   -- how long the SERVER took to answer the last page
     fastGate      = false, -- gate has opened fast enough to mean "throttle lifted"
     callbacks     = nil,   -- { onPage = fn(page1, totalPages),
                            --   onComplete = fn(stats) }
@@ -159,6 +164,7 @@ local function SendQuery()
     st.sent = st.sent + 1
     st.phase = "wait_results"
     st.timeout = scan.REPLY_TIMEOUT
+    st.sentAt = st.elapsed   -- to measure the server's round trip
     scan.Debug(string.format(
         "query sent \226\128\148 cat %d, page %d (attempt %d)",
         st.queryIndex, st.page, st.retries + 1))
@@ -294,9 +300,16 @@ function scan.OnListUpdate()
     st.scanned = st.scanned + numOnPage
     st.lastCompleted = st.page
     st.retries = 0
+    -- How long the SERVER took to answer. Together with the gate wait this
+    -- accounts for the whole per-page cost, so a slow scan can be blamed
+    -- correctly: our floor, the client's throttle, or the server itself.
+    if st.sentAt then
+        st.lastReply = st.elapsed - st.sentAt
+        st.sentAt = nil
+    end
     scan.Debug(string.format(
-        "page %d / %d received \226\128\148 %d on page, %d total",
-        st.page + 1, st.totalPages, numOnPage, totalAuctions))
+        "page %d / %d received in %.2fs \226\128\148 %d on page, %d total",
+        st.page + 1, st.totalPages, st.lastReply or 0, numOnPage, totalAuctions))
     if st.callbacks and st.callbacks.onPage then
         st.callbacks.onPage(st.page + 1, st.totalPages)
     end
@@ -349,6 +362,8 @@ function scan.Start(queryOrList, callbacks)
     st.waitOk         = 0
     st.gateWait       = 0
     st.lastGate       = nil
+    st.lastReply      = nil
+    st.sentAt         = nil
     st.fastGate       = false
     StartCurrentQuery()
     st.cooldown       = 0    -- first query goes as soon as the client allows
@@ -434,6 +449,7 @@ function scan.GetProgress()
         retries     = st.retries or 0,
         phase       = st.phase,
         lastGate    = st.lastGate,
+        lastReply   = st.lastReply,
         fastGate    = st.fastGate and true or false,
     }
 end

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -699,12 +699,17 @@ function ui.RefreshSettings()
             ui.setThrottleInfo:SetText("fixed 4s between pages")
             ui.setThrottleInfo:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
         elseif p.fastGate then
+            -- Show BOTH halves of the per-page cost. If the gate is ~0 and the
+            -- reply is slow, the server is the limit, not us -- which is why
+            -- the same scan can differ between realms.
             ui.setThrottleInfo:SetText(string.format(
-                "fast \226\128\148 gate opened in %.2fs", p.lastGate or 0))
+                "fast \226\128\148 gate %.2fs, server %.2fs",
+                p.lastGate or 0, p.lastReply or 0))
             ui.setThrottleInfo:SetTextColor(0.30, 0.85, 0.30)
         elseif p.lastGate then
             ui.setThrottleInfo:SetText(string.format(
-                "client throttled \226\128\148 gate took %.1fs", p.lastGate))
+                "client throttled \226\128\148 gate %.1fs, server %.2fs",
+                p.lastGate, p.lastReply or 0))
             ui.setThrottleInfo:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
         else
             ui.setThrottleInfo:SetText("follows the client's own query gate")


### PR DESCRIPTION
## "Are we throttling the fast path at all?"

**Yes, slightly — and you were right to ask.** I'd left a **0.25s floor** between pages. That's *per page*, so a 60-page scan spent about **15 seconds waiting on us** rather than on the server. Cut to **0.05s** (about a frame). The client's `CanSendAuctionQuery()` gate is the real throttle; this floor now only stops us re-testing it every single frame.

## "Or is this a back-end thing? Faster on OctoWoW vs CapyWoW"

Almost certainly, yes — and rather than speculate, Aegis now **measures it** so you can tell.

The per-page cost has exactly two parts, and both are now timed and shown:

```
fast — gate 0.02s, server 0.61s
```

- **gate** — how long the client's throttle held us back (≈0 means AuctionQueryThrottle is working)
- **server** — how long the realm took to answer

If gate is ~0 and server is 0.6s on one realm and 0.2s on another, that difference **is** the back end, and there's nothing addon-side left to win. The same numbers go to `/aex debug` per page.

## README

Adopted your badge block, keeping your grouping: **Discord → 1.18.1 servers → Required loaders → Recommended**. I added **AuctionQueryThrottle** to the Recommended row (it's directly relevant now) and generalised the tagline off Turtle alone, since Octo and Capy now lead the badges.

I also recorded the convention in `CLAUDE.md` so it's maintained going forward: the badge block and its grouping are owner-maintained, the shields.io style stays consistent, and the Discord invite must stay identical in **all five** places it appears.

> ⚠️ **One thing to check:** the block you pasted uses `discord.gg/hsgPTNkSX`, but your recent commit *"Change Discord link to new invite"* set `discord.gg/Hr66t25vE7`. I went with the one you just pasted and made all five references consistent — but if `Hr66t25vE7` is the current invite, say the word and I'll flip them all back.

> Version **0.21.1**; `/reload` is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_