### PR TITLE
Record the badge/Discord conventions after the owner's edits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,14 +189,18 @@ are done in practice — **imitate the approach, do not copy code blindly**:
 ## README / CHANGELOG upkeep
 
 - **The badge block at the top of `README.md` is maintained by the project
-  owner.** It is grouped deliberately — Discord, then the 1.18.1 servers (Octo
-  WoW / Capy WoW), then **Required** loaders (SuperWoW, Nampower, UnitXP_SP3),
-  then **Recommended** (ClassicAPI, SCRM, AuctionQueryThrottle, pfUI). Keep that
-  grouping and the shields.io style (`flat-square`, `labelColor=555`) when
-  adding to it; do not reorder or restyle it unasked.
-- **One Discord invite, used everywhere.** It appears in the badge, the intro
-  line, "Something broken?", Contributing and the footer — change all of them
-  together or none.
+  owner.** It is two rows, deliberately:
+  1. Discord, the 1.18.1 servers (Octo WoW / Capy WoW), pfUI.
+  2. The loaders — **Required** in purple (`8A2BE2`: SuperWoW, Nampower,
+     UnitXP_SP3) then **Recommended** in amber (`dfb317`: ClassicAPI, SCRM,
+     AuctionQueryThrottle). The colour carries the distinction, not the row.
+
+  Keep the shields.io style (`flat-square`, `labelColor=555`) when adding to it,
+  and do not reorder, re-row or restyle it unasked.
+- **One Discord invite, used everywhere: `https://discord.gg/Hr66t25vE7`.** It
+  appears in five places — the badge, the intro line, "Something broken?",
+  Contributing and the footer. Change all five together or none, and never
+  swap it for one pasted in chat without confirming it is current.
 - Every version bump gets a `CHANGELOG.md` entry. Mark a release **restart**
   when it adds a new `.lua` file to the `.toc`.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 [![SCRM](https://img.shields.io/badge/SCRM-Recommended-dfb317?style=flat-square&labelColor=555)](https://github.com/brues-code/SuperCleveRoidMacros)
 [![AuctionQueryThrottle](https://img.shields.io/badge/AuctionQueryThrottle-Recommended-dfb317?style=flat-square&labelColor=555)](https://github.com/brues-code/AuctionQueryThrottle)
 
-
 The stock 1.12 auction house is three text boxes and a prayer. Aegis replaces it
 with a window that actually knows what things are worth — what you should charge,
 what you should pay, whether that recipe is worth crafting, and how much gold you


### PR DESCRIPTION
## Review of your Discord fix

✅ **Clean.** All five references are `Hr66t25vE7`, and no stale invite survives anywhere in the repo (checked `.md`, `.lua`, `.toc`). Every internal README anchor still resolves.

## Two follow-ups

**1. Stray blank line** — there was a double blank line left between the badge block and the intro paragraph. Collapsed.

**2. `CLAUDE.md` was out of date with your layout.** My earlier note described a *four-row* badge block, but you regrouped it into **two** rows. Documented what you actually settled on:

- **Row 1:** Discord, Octo WoW, Capy WoW, pfUI
- **Row 2:** the loaders — **Required** in purple (`8A2BE2`), **Recommended** in amber (`dfb317`)

with the key point that **the colour carries the Required/Recommended distinction, not the row** — so a future edit doesn't "helpfully" split them back apart.

I also pinned **`https://discord.gg/Hr66t25vE7`** as the canonical invite, with an explicit note not to swap it for one pasted in chat without confirming it's current. That's precisely the mistake I made last round, so it's now written down rather than left to memory.

> Docs only — no Lua changed, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_