### PR TITLE
Cancel-all-undercuts, scan report, flat-1c defaults; fix two posting bugs (v0.22.0)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.21.1
+## Version: 0.22.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [0.22.0]
+
+### Added
+- **Cancel all undercuts** on the Auctions tab — one button, labelled with the
+  count, that cancels every auction someone is currently beating. It works from
+  the highest owner index down, because cancelling shifts the later indices.
+- **"Ask before cancelling an auction"** toggle on the Aegis tab. Turn it off and
+  Cancel (single or bulk) acts on the first click.
+- **Scan results report.** Finishing a scan now prints a breakdown: auctions
+  scanned, distinct items, a per-quality tally in item colours, items added vs.
+  updated in the price DB, items ignored, and pages/duration.
+
+### Changed
+- **Shipping defaults are now undercut / flat / 1 copper** — cheapest by the
+  smallest possible margin, rather than giving away 5%.
+- Badge colours: Octo WoW purple, Capy WoW brown, Required red, Recommended
+  orange. The pfUI badge is gone (it was never required) — the "Using pfUI?"
+  section says so instead.
+- README leads with an **AuctionQueryThrottle** notice, including that the gain
+  is realm-dependent (Octo WoW dramatically faster, Capy WoW roughly 2×), and a
+  note that Aegis itself calls **only** vanilla 1.12 API — the loader badges
+  describe the recommended realm setup, not Aegis's own dependencies.
+
+### Fixed
+- **"Posted 0 of 1 — couldn't assemble a stack."** `SplitContainerItem` only
+  splits *part* of a stack; asking it for the whole stack is a no-op on 1.12, so
+  the cursor stayed empty and the job died after retrying. Posting a single full
+  stack always hit this. The assembler now picks the whole stack up instead.
+  (The harness's sim happily split whole stacks, which is why this was never
+  caught — it now models the real no-op.)
+- **The post-scan queue sometimes slotted the wrong item, or nothing.** It used
+  the bag/slot captured when the queue was built, and posting shifts bags. It now
+  re-locates each item by itemId via the new `sell.FindItemSlot`.
+
 ## [0.21.1]
 
 ### Changed
@@ -227,4 +261,4 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
-[0.21.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
+[0.22.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,10 +190,14 @@ are done in practice — **imitate the approach, do not copy code blindly**:
 
 - **The badge block at the top of `README.md` is maintained by the project
   owner.** It is two rows, deliberately:
-  1. Discord, the 1.18.1 servers (Octo WoW / Capy WoW), pfUI.
-  2. The loaders — **Required** in purple (`8A2BE2`: SuperWoW, Nampower,
-     UnitXP_SP3) then **Recommended** in amber (`dfb317`: ClassicAPI, SCRM,
+  1. Discord (`5865F2`), then the 1.18.1 servers — Octo WoW purple (`8A2BE2`),
+     Capy WoW brown (`8B5A2B`).
+  2. The loaders — **Required** in red (`d62728`: SuperWoW, Nampower,
+     UnitXP_SP3) then **Recommended** in orange (`ff8c00`: ClassicAPI,
      AuctionQueryThrottle). The colour carries the distinction, not the row.
+
+  There is deliberately **no pfUI badge** — pfUI is optional, and the "Using
+  pfUI?" section says so instead. Do not re-add it.
 
   Keep the shields.io style (`flat-square`, `labelColor=555`) when adding to it,
   and do not reorder, re-row or restyle it unasked.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@
 **A clean, fast auction house for vanilla WoW (1.12).**
 
 [![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/Hr66t25vE7)
-[![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-4c1?style=flat-square&labelColor=555)](https://octowow.st/)
-[![Capy WoW](https://img.shields.io/badge/Capy%20WoW-1.18.1-4c1?style=flat-square&labelColor=555)](https://capycraft.io/)
-[![pfUI](https://img.shields.io/badge/pfUI-skin%20included-33ffcc?style=flat-square&labelColor=555)](#using-pfui)
+[![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-8A2BE2?style=flat-square&labelColor=555)](https://octowow.st/)
+[![Capy WoW](https://img.shields.io/badge/Capy%20WoW-1.18.1-8B5A2B?style=flat-square&labelColor=555)](https://capycraft.io/)
 
-[![SuperWoW](https://img.shields.io/badge/SuperWoW-Required-8A2BE2?style=flat-square&labelColor=555)](https://github.com/balakethelock/SuperWoW)
-[![Nampower](https://img.shields.io/badge/Nampower-Required-8A2BE2?style=flat-square&labelColor=555)](https://github.com/brues-code/nampower)
-[![UnitXP_SP3](https://img.shields.io/badge/UnitXP__SP3-Required-8A2BE2?style=flat-square&labelColor=555)](https://codeberg.org/konaka/UnitXP_SP3)
-[![ClassicAPI](https://img.shields.io/badge/ClassicAPI-Recommended-dfb317?style=flat-square&labelColor=555)](https://github.com/brues-code/ClassicAPI)
-[![AuctionQueryThrottle](https://img.shields.io/badge/AuctionQueryThrottle-Recommended-dfb317?style=flat-square&labelColor=555)](https://github.com/brues-code/AuctionQueryThrottle)
+[![SuperWoW](https://img.shields.io/badge/SuperWoW-Required-d62728?style=flat-square&labelColor=555)](https://github.com/balakethelock/SuperWoW)
+[![Nampower](https://img.shields.io/badge/Nampower-Required-d62728?style=flat-square&labelColor=555)](https://github.com/brues-code/nampower)
+[![UnitXP_SP3](https://img.shields.io/badge/UnitXP__SP3-Required-d62728?style=flat-square&labelColor=555)](https://codeberg.org/konaka/UnitXP_SP3)
+[![ClassicAPI](https://img.shields.io/badge/ClassicAPI-Recommended-ff8c00?style=flat-square&labelColor=555)](https://github.com/brues-code/ClassicAPI)
+[![AuctionQueryThrottle](https://img.shields.io/badge/AuctionQueryThrottle-Recommended-ff8c00?style=flat-square&labelColor=555)](https://github.com/brues-code/AuctionQueryThrottle)
 
 The stock 1.12 auction house is three text boxes and a prayer. Aegis replaces it
 with a window that actually knows what things are worth — what you should charge,
@@ -21,6 +20,19 @@ made this week.
 > Built for **1.18.1** servers (Octo WoW, Capy WoW, Turtle WoW), which run the
 > original **WoW 1.12 (vanilla)** client on **Lua 5.0**. Not Classic. Not retail.
 > Real vanilla.
+
+> ### ⚡ Scans fastest with AuctionQueryThrottle
+> Vanilla makes the client sit out ~5 seconds between auction queries.
+> **[AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle)**
+> clears that timer the moment the server replies, and Aegis picks the change up
+> **automatically** — nothing to configure.
+>
+> How much you gain depends on the realm, because what's left is the server's own
+> response time: **Octo WoW** is dramatically faster, while **Capy WoW** lands at
+> roughly **2×**. The Aegis tab tells you which you're getting
+> (`fast — gate 0.02s, server 0.61s`).
+>
+> It's a DLL, not an addon, and it needs the VanillaFixes loader.
 
 **[💬 Join the Discord](https://discord.gg/Hr66t25vE7)** for help, bug reports,
 and feature ideas.
@@ -112,6 +124,9 @@ value, minimum buyout, and vendor price, with stack totals.
 
 ## Using pfUI?
 
+> There's no pfUI badge above on purpose — pfUI is **not required**. Aegis simply
+> notices it and matches its look.
+
 Aegis notices and **restyles itself to match** — pfUI's borders, buttons,
 checkboxes and scrollbars instead of vanilla tooltip frames. Nothing to install;
 it just happens. Turn it off any time with **"Match pfUI's look"** on the Aegis
@@ -184,6 +199,12 @@ numbers, % colours, and profit estimates fill in as you go.
     which you're getting (`fast — gate opened in 0.28s`), and **Safe 4s** pacing
     is there if you ever want the old fixed floor back.
 - **Mail sale-tracking is enUS-only** right now (it matches "Auction successful:").
+- **What Aegis itself needs: nothing but the client.** It calls only vanilla 1.12
+  API. The loader badges above describe the recommended setup for these realms
+  (and the wider Aegis addon series) — Aegis: Exchange does not call SuperWoW,
+  Nampower or UnitXP_SP3, and runs fine without them.
+  [AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle) is
+  the one that changes anything here, and only how fast scans go.
 
 ---
 
@@ -218,7 +239,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v0.21.1`) — quote it.
+1. Check the **version** in the window's title bar (`v0.22.0`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/Hr66t25vE7)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/core/db.lua
+++ b/core/db.lua
@@ -80,9 +80,12 @@ local LEDGER_MAX = 500
 -- new setting here is enough -- no migration of old saves needed.
 local SETTING_DEFAULTS = {
     duration       = 480,       -- default post duration, minutes (120/480/1440)
-    undercutMode   = "pct",     -- "pct" (percent) or "flat" (fixed copper)
+    -- Default pricing: undercut the lowest competitor by a FLAT 1 copper. That
+    -- is the behaviour most sellers want out of the box -- just enough to be
+    -- cheapest without giving away margin.
+    undercutMode   = "flat",    -- "pct" (percent) or "flat" (fixed copper)
     undercutPct    = 5,         -- percent below the reference (pct mode)
-    undercutAmount = 100,       -- copper below the reference (flat mode; 1s)
+    undercutAmount = 1,         -- copper below the reference (flat mode)
     sellDefault    = "undercut", -- slot prefill: "undercut"|"market"|"none"
     tooltip        = true,      -- show Aegis price lines on item tooltips
     profLine       = true,      -- show the profit line on profession windows
@@ -93,6 +96,9 @@ local SETTING_DEFAULTS = {
     --            soon as the reply lands, so scans speed up automatically.
     --   "safe" -- always keep the fixed 4s floor as well.
     queryThrottle  = "auto",
+    -- Ask before cancelling an auction. Off = cancel on the first click, which
+    -- is what you want when clearing a lot of undercuts by hand.
+    confirmCancel  = true,
 }
 
 -- Read a user setting, falling back to its default when unset.

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.21.1"
+A.version = "0.22.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/scan.lua
+++ b/core/scan.lua
@@ -100,9 +100,21 @@ scan.state = {
     sentAt        = nil,   -- st.elapsed when the current query went out
     lastReply     = nil,   -- how long the SERVER took to answer the last page
     fastGate      = false, -- gate has opened fast enough to mean "throttle lifted"
+    tally         = nil,   -- per-run stats for the completion report (see NewTally)
     callbacks     = nil,   -- { onPage = fn(page1, totalPages),
                            --   onComplete = fn(stats) }
 }
+
+-- 1.12 quality indices, for the scan report.
+scan.QUALITY_NAMES = { [0] = "Poor", [1] = "Common", [2] = "Uncommon",
+                       [3] = "Rare", [4] = "Epic", [5] = "Legendary",
+                       [6] = "Artifact" }
+
+-- Fresh per-run tally. `seen` maps itemId -> quality so each distinct item is
+-- counted once; added/updated split on whether the price DB already knew it.
+local function NewTally()
+    return { seen = {}, distinct = 0, added = 0, updated = 0, ignored = 0 }
+end
 
 -- Chat trace of every scanner transition; toggled with "/aex debug". This is
 -- how we tell WHICH leg a stall is on: query never sent (CanSendAuctionQuery
@@ -130,11 +142,31 @@ end
 local function RecordVisiblePage(numOnPage)
     local st = scan.state
     local onListing = st.callbacks and st.callbacks.onListing
+    local tally = st.tally
     for i = 1, numOnPage do
-        local name, _, count, _, _, _, minBid, _, buyoutPrice, _, _, owner =
+        local name, _, count, quality, _, _, minBid, _, buyoutPrice, _, _, owner =
             GetAuctionItemInfo("list", i)
         if name and count and count > 0 then
             local itemId = util.ItemIdFromLink(GetAuctionItemLink("list", i))
+            -- Tally BEFORE recording, so "added" means new to the price DB.
+            if tally then
+                if itemId then
+                    if not tally.seen[itemId] then
+                        local known = A.db.account
+                            and A.db.account.items[itemId] or nil
+                        tally.seen[itemId] = quality or 1
+                        tally.distinct = tally.distinct + 1
+                        if known then
+                            tally.updated = tally.updated + 1
+                        else
+                            tally.added = tally.added + 1
+                        end
+                    end
+                else
+                    -- No resolvable item link: nothing we can price.
+                    tally.ignored = tally.ignored + 1
+                end
+            end
             if buyoutPrice and buyoutPrice > 0 and itemId then
                 A.db.RecordAuction(
                     itemId, math.floor(buyoutPrice / count), name)
@@ -254,6 +286,20 @@ local function Finish()
         duration   = st.elapsed,
         categories = table.getn(st.queries),
     }
+    -- Roll the per-run tally into the report: distinct items, a per-quality
+    -- breakdown, and how many items were new to the price DB vs. refreshed.
+    local t = st.tally
+    if t then
+        local byQuality = {}
+        for _, q in pairs(t.seen) do
+            byQuality[q] = (byQuality[q] or 0) + 1
+        end
+        stats.items     = t.distinct
+        stats.byQuality = byQuality
+        stats.added     = t.added
+        stats.updated   = t.updated
+        stats.ignored   = t.ignored
+    end
     -- Item scans (Sell tab price lookups) pass stampLast=false so they feed
     -- the price DB WITHOUT resetting the Scan tab's "last full scan" marker.
     if not (st.callbacks and st.callbacks.stampLast == false) then
@@ -360,6 +406,7 @@ function scan.Start(queryOrList, callbacks)
     st.sent           = 0
     st.retries        = 0
     st.waitOk         = 0
+    st.tally          = NewTally()
     st.gateWait       = 0
     st.lastGate       = nil
     st.lastReply      = nil

--- a/core/sell.lua
+++ b/core/sell.lua
@@ -645,6 +645,44 @@ function sell.PlaceFromBag(bag, slot)
     ClickAuctionSellItemButton()
 end
 
+-- Where does `itemId` live in the bags RIGHT NOW? Returns (bag, slot) for the
+-- largest auctionable stack, or nil.
+--
+-- Bag positions shift as you post, so any bag/slot captured earlier can be
+-- stale (that slot may now be empty or hold something else). Anything acting on
+-- a remembered item -- the post-scan sell queue especially -- must re-locate it
+-- through here rather than trusting the old coordinates.
+function sell.FindItemSlot(itemId)
+    if not itemId then return nil end
+    local bestBag, bestSlot, bestCount = nil, nil, 0
+    local bag = 0
+    while bag <= 4 do
+        local slots = GetContainerNumSlots(bag) or 0
+        local slot = 1
+        while slot <= slots do
+            local link = GetContainerItemLink(bag, slot)
+            if link and util.ItemIdFromLink(link) == itemId
+                and sell.IsAuctionable(bag, slot) then
+                local _, count = GetContainerItemInfo(bag, slot)
+                if (count or 0) > bestCount then
+                    bestBag, bestSlot, bestCount = bag, slot, count or 0
+                end
+            end
+            slot = slot + 1
+        end
+        bag = bag + 1
+    end
+    return bestBag, bestSlot
+end
+
+-- Place `itemId` into the sell slot, finding it fresh. Returns true if placed.
+function sell.PlaceItemById(itemId)
+    local bag, slot = sell.FindItemSlot(itemId)
+    if not bag then return false end
+    sell.PlaceFromBag(bag, slot)
+    return true
+end
+
 -- ---------------------------------------------------------------------------
 -- Posting
 -- ---------------------------------------------------------------------------
@@ -867,7 +905,19 @@ function sell.PostTick(dt)
             FinishJob("out")             -- can't build another stack
             return
         end
-        SplitContainerItem(bag, slot, job.stackSize)   -- stackSize onto cursor
+        -- CRITICAL: SplitContainerItem is for taking PART of a stack. Asking it
+        -- to split the WHOLE stack (count == what's in the slot) is a no-op on
+        -- 1.12, so the cursor stays empty, ClickAuctionSellItemButton does
+        -- nothing, verify never sees the item, and the job died with
+        -- "couldn't assemble a stack" -- which is exactly the
+        -- "Posted 0 of 1" failure, since a single full stack always hits this.
+        -- Pick the whole stack up instead when the counts match.
+        local _, slotCount = GetContainerItemInfo(bag, slot)
+        if (slotCount or 0) <= job.stackSize then
+            PickupContainerItem(bag, slot)             -- whole stack -> cursor
+        else
+            SplitContainerItem(bag, slot, job.stackSize)   -- part of it
+        end
         ClickAuctionSellItemButton()                   -- cursor -> sell slot
         job.phase = "verify"
         job.cool = ASSEMBLE_DELAY

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -553,11 +553,27 @@ function ui.BuildAegisSettings(panel, anchorAbove)
     end)
     ui.setPfSkin = pfChk
 
+    -- Ask before cancelling an auction? Off makes the Auctions tab's Cancel
+    -- buttons act immediately.
+    local ccChk = CreateFrame("CheckButton", "AegisExchangeSetConfirmCancel",
+        panel, "UICheckButtonTemplate")
+    ccChk:SetWidth(24); ccChk:SetHeight(24)
+    ccChk:SetPoint("TOPLEFT", pfChk, "BOTTOMLEFT", 0, -4)
+    local ccTxt = getglobal(ccChk:GetName() .. "Text")
+    if ccTxt then
+        ccTxt:SetText("Ask before cancelling an auction")
+        ccTxt:SetTextColor(C.text[1], C.text[2], C.text[3])
+    end
+    ccChk:SetScript("OnClick", function()
+        A.db.SetSetting("confirmCancel", ccChk:GetChecked() and true or false)
+    end)
+    ui.setConfirmCancel = ccChk
+
     -- ---- Scan pacing -------------------------------------------------------
     -- "Auto" leans on the client's own CanSendAuctionQuery() gate, so a client
     -- running the AuctionQueryThrottle DLL scans as fast as the server answers
     -- while a stock client still waits its ~5s. "Safe" keeps the fixed floor.
-    local thLbl = label("Scan pacing:", pfChk, -12)
+    local thLbl = label("Scan pacing:", ccChk, -12)
 
     ui.setThrottleBtns = {}
     local modes = { { "Auto", "auto" }, { "Safe 4s", "safe" } }
@@ -667,6 +683,10 @@ function ui.RefreshSettings()
     if ui.setProfLine then
         ui.setProfLine:SetChecked(A.db.Setting("profLine") ~= false and 1 or nil)
     end
+    if ui.setConfirmCancel then
+        ui.setConfirmCancel:SetChecked(
+            A.db.Setting("confirmCancel") ~= false and 1 or nil)
+    end
     if ui.setPfSkin then
         ui.setPfSkin:SetChecked(A.db.Setting("pfSkin") ~= false and 1 or nil)
         -- Without pfUI the toggle does nothing; grey it out rather than lie.
@@ -773,11 +793,49 @@ function ui.StartFullScan()
     ui.StartScan({})
 end
 
+-- Quality report order (best first) and their standard item colours.
+local SCAN_QUALITY_ORDER = { 6, 5, 4, 3, 2, 1, 0 }
+local SCAN_QUALITY_COLOR = {
+    [0] = "9d9d9d", [1] = "ffffff", [2] = "1eff00", [3] = "0070dd",
+    [4] = "a335ee", [5] = "ff8000", [6] = "e6cc80",
+}
+
+-- Full breakdown once a scan finishes: totals, a per-quality tally, and what
+-- it did to the price DB. Printed as separate lines so it reads like a report
+-- rather than one dense sentence.
 function ui.OnScanComplete(stats)
     ui.Refresh()
-    ChatMsg(string.format(
-        "Aegis: scan complete \226\128\148 %d auctions across %d pages in %s.",
-        stats.auctions, stats.pages, util.FormatDuration(stats.duration)))
+    local function line(text)
+        DEFAULT_CHAT_FRAME:AddMessage("|cff5fc8f8Aegis:|r " .. text,
+            0.35, 0.78, 0.98)
+    end
+
+    local head = stats.auctions .. " auctions scanned"
+    if stats.items then head = head .. "  (" .. stats.items .. " items)" end
+    line(head)
+
+    -- Per quality, best first, each in its own item colour. Skip empties.
+    if stats.byQuality then
+        local qi = 1
+        while qi <= table.getn(SCAN_QUALITY_ORDER) do
+            local q = SCAN_QUALITY_ORDER[qi]
+            local n = stats.byQuality[q]
+            if n and n > 0 then
+                local name = A.scan.QUALITY_NAMES[q] or ("Quality " .. q)
+                line("  |cff" .. (SCAN_QUALITY_COLOR[q] or "ffffff")
+                    .. name .. " items:|r " .. n)
+            end
+            qi = qi + 1
+        end
+    end
+
+    if stats.added then
+        line("  Items added to database: " .. stats.added)
+        line("  Items updated in database: " .. (stats.updated or 0))
+        line("  Items ignored: " .. (stats.ignored or 0))
+    end
+    line("  Scanned " .. stats.pages .. " page(s) in "
+        .. util.FormatDuration(stats.duration))
 end
 
 -- Live scan progress as one line ("Page 3 / 6 - ~12s - 16.6/s"), or nil when
@@ -2401,6 +2459,15 @@ function ui.BuildAuctionsTab()
     refresh:SetText("Refresh")
     refresh:SetScript("OnClick", function() ui.RefreshAuctions(true) end)
 
+    -- Clear out everything you've been undercut on in one go.
+    local cancelAll = CreateFrame("Button", "AegisExchangeAucCancelAllButton",
+        panel, "UIPanelButtonTemplate")
+    cancelAll:SetWidth(132); cancelAll:SetHeight(20)
+    cancelAll:SetPoint("RIGHT", refresh, "LEFT", -6, 0)
+    cancelAll:SetText("Cancel all undercuts")
+    cancelAll:SetScript("OnClick", function() ui.ConfirmCancelAllUndercut() end)
+    ui.aucCancelAllBtn = cancelAll
+
     ui.aucStatus = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
     ui.aucStatus:SetPoint("TOPLEFT", panel, "TOPLEFT", 10, -34)
     ui.aucStatus:SetJustifyH("LEFT")
@@ -2488,6 +2555,19 @@ function ui.UpdateAuctionsList()
 
     local cap = A.sell.CAP or 120
     ui.aucSummary:SetText("Your auctions: " .. total .. " / " .. cap)
+
+    -- Label the bulk-cancel with how many are actually undercut, and disable it
+    -- when there's nothing to do.
+    if ui.aucCancelAllBtn then
+        local nUnder = table.getn(ui.UndercutAuctions())
+        if nUnder > 0 then
+            ui.aucCancelAllBtn:SetText("Cancel " .. nUnder .. " undercut")
+            ui.aucCancelAllBtn:Enable()
+        else
+            ui.aucCancelAllBtn:SetText("No undercuts")
+            ui.aucCancelAllBtn:Disable()
+        end
+    end
     if total == 0 then
         ui.aucStatus:SetText("No active auctions. Post some on the Sell tab.")
     else
@@ -2564,7 +2644,77 @@ StaticPopupDialogs["AEGIS_EXCHANGE_CANCEL"] = {
 
 function ui.ConfirmCancelAuction(r)
     ui.pendingCancel = r
+    -- The Aegis tab can turn the confirmation off, which is what you want when
+    -- clearing a pile of undercuts by hand.
+    if A.db.Setting("confirmCancel") == false then
+        ui.DoCancelAuction()
+        return
+    end
     StaticPopup_Show("AEGIS_EXCHANGE_CANCEL", r.name .. " (x" .. r.count .. ")")
+end
+
+-- ---- cancel every undercut auction --------------------------------------
+
+-- Auctions of ours that someone is currently beating on unit price.
+function ui.UndercutAuctions()
+    local out = {}
+    local rows = ui.aucAuctions or {}
+    local i = 1
+    while i <= table.getn(rows) do
+        local r = rows[i]
+        local mkt = r.itemId and A.db.MinBuyout(r.itemId)
+        if mkt and mkt > 0 and r.unit and r.unit > mkt then
+            table.insert(out, r)
+        end
+        i = i + 1
+    end
+    return out
+end
+
+StaticPopupDialogs["AEGIS_EXCHANGE_CANCELALL"] = {
+    text = "Cancel %s?\n%s\nThe items return by mail; deposits are lost.",
+    button1 = "Cancel them", button2 = "Keep",
+    OnAccept = function() ui.DoCancelAllUndercut() end,
+    timeout = 0, whileDead = 1, hideOnEscape = 1,
+}
+
+function ui.ConfirmCancelAllUndercut()
+    local rows = ui.UndercutAuctions()
+    local n = table.getn(rows)
+    if n == 0 then
+        ChatMsg("Aegis: nothing of yours is undercut.")
+        return
+    end
+    if A.db.Setting("confirmCancel") == false then
+        ui.DoCancelAllUndercut()
+        return
+    end
+    local names, i = {}, 1
+    while i <= n and i <= 4 do
+        table.insert(names, rows[i].name .. " x" .. rows[i].count)
+        i = i + 1
+    end
+    local detail = table.concat(names, ", ")
+    if n > 4 then detail = detail .. ", +" .. (n - 4) .. " more" end
+    StaticPopup_Show("AEGIS_EXCHANGE_CANCELALL",
+        n .. " undercut auction(s)", detail)
+end
+
+-- Cancel them from the HIGHEST owner index down: cancelling shifts every later
+-- index down by one, so walking upward would skip auctions.
+function ui.DoCancelAllUndercut()
+    local rows = ui.UndercutAuctions()
+    local n = table.getn(rows)
+    if n == 0 then return end
+    table.sort(rows, function(a, b) return a.index > b.index end)
+    local done = 0
+    local i = 1
+    while i <= n do
+        if A.sell.CancelOwnerAuction(rows[i].index) then done = done + 1 end
+        i = i + 1
+    end
+    ChatMsg("Aegis: cancelled " .. done .. " undercut auction(s).")
+    ui.RefreshAuctions(true)
 end
 
 function ui.DoCancelAuction()
@@ -4118,9 +4268,11 @@ function ui.AdvanceSellQueue()
     -- Skip anything no longer in bags (already posted or moved).
     while i <= table.getn(q) do
         local item = q[i]
-        if item.itemId and A.sell.CountInBags(item.itemId) > 0 then
+        -- Re-locate by itemId: the bag/slot captured when the queue was built
+        -- goes stale as posting shifts bags around, which is why the walk
+        -- sometimes slotted the wrong item (or nothing) instead of the next one.
+        if item.itemId and A.sell.PlaceItemById(item.itemId) then
             ui.sellQueueIndex = i
-            A.sell.PlaceFromBag(item.bag, item.slot)
             ui.RefreshSell()
             if ui.sellStatus then
                 ui.sellStatus:SetText("Item " .. i .. " of " .. table.getn(q)


### PR DESCRIPTION
## 🐛 Two real posting bugs — both found and fixed

### `Posted 0 of 1. (couldn't assemble a stack)`
`SplitContainerItem` splits **part** of a stack. Asking it for the **whole** stack is a **no-op on 1.12** — so the cursor stayed empty, the sell slot never filled, `verify` failed its retries, and the job died. **Posting a single full stack always hit this**, which is exactly your screenshot.

The assembler now **picks the whole stack up** when the slot count equals the stack size, and only splits when there's genuinely more in the slot.

> The harness's simulator happily split whole stacks — *which is precisely why this was never caught.* It now models the real no-op, and I verified the new regression test **fails without the fix and passes with it**.

### Posting didn't always get the next item
The post-scan queue used the bag/slot captured **when the queue was built** — but posting shifts bags around, so that slot goes stale and it slotted the wrong item (or nothing). It now **re-locates each item by itemId** at advance time via the new `sell.FindItemSlot`.

Also made the sim faithful: `StartAuction` now consumes the stack however it reached the slot, rather than relying on the split path having removed it early.

## ✨ Added
- **Cancel all undercuts** on the Auctions tab — labelled with the live count, disabled when there's nothing to do. Cancels from the **highest owner index down**, since cancelling shifts every later index.
- **"Ask before cancelling an auction"** toggle on the Aegis tab. Off = both per-row and bulk Cancel act on the first click.
- **Scan results report**, in the style of your screenshot: auctions scanned, distinct items, per-quality tally in item colours, items **added vs updated** in the price DB, items ignored, pages/duration.

## 🎨 Changed
- **Defaults are now undercut / flat / 1 copper.**
- Badge colours: **Octo WoW purple, Capy WoW brown, Required red, Recommended orange**. **pfUI badge removed** — the "Using pfUI?" section notes it isn't required instead.
- README now **leads with an AuctionQueryThrottle notice**, including that the gain is realm-dependent (**Octo WoW dramatically faster, Capy WoW ~2×**).

## 📋 Your question: what's actually required?

I checked the source rather than guessing — **Aegis calls none of them**:

| Mod | Used by Aegis? |
|---|---|
| SuperWoW | ❌ no calls |
| Nampower | ❌ no calls |
| UnitXP_SP3 | ❌ no calls |
| **AuctionQueryThrottle** | ✅ **the only one that changes anything** (scan speed) |

Aegis uses **only vanilla 1.12 API**. I kept your badges (they describe the recommended realm setup / wider Aegis series) but added an honest line to "A few honest notes" saying Aegis itself needs nothing but the client — so nobody thinks they must install three DLLs for an AH addon.

### ClassicAPI deep-dive (your ToDo)
It's a **DLL** that backports modern APIs. Relevant surface:
- `C_Container.GetContainerItemID` — the one genuinely useful bit: we currently derive item IDs by **string-parsing container links**, so this would be cheaper and more robust in bag scans.
- `C_AuctionHouse.PostItem`, `C_Item.*`, `GetMerchantItemID`, tooltip 30→60 line lift.

**Verdict: not needed, small optional win.** The honest gain is modest (bag scans parse ~100 links), and it'd need a fallback anyway. If you want it, I'd add an opportunistic fast path — use `GetContainerItemID` when present, parse the link otherwise. Say the word.

## Note on the merge
Your `Update README.md` (removing the **SCRM** badge) landed while I was working. I resolved the conflict keeping **your removal** plus my new colours, and updated CLAUDE.md's badge convention to match so it no longer lists SCRM.

> Version **0.22.0**; `/reload` is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_