### PR TITLE
Release v1.1.0

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 0.22.0
+## Version: 1.1.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
-## [0.22.0]
+## [1.1.0] — first public release
+
+> Aegis: Exchange is officially released. Everything below 1.1.0 was
+> pre-release development; the feature set it shipped with is the sum of it.
 
 ### Added
 - **Cancel all undercuts** on the Auctions tab — one button, labelled with the
@@ -261,4 +264,4 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
-[0.22.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
+[1.1.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,16 @@ are done in practice — **imitate the approach, do not copy code blindly**:
   swap it for one pasted in chat without confirming it is current.
 - Every version bump gets a `CHANGELOG.md` entry. Mark a release **restart**
   when it adds a new `.lua` file to the `.toc`.
+- **A version bump touches FOUR places** — miss one and the in-game version
+  stops matching the release:
+  1. `core/init.lua` — `A.version`
+  2. `Aegis_Exchange.toc` — `## Version:`
+  3. `README.md` — the version badge **and** the "Check the version" line
+  4. `CHANGELOG.md` — a new entry plus the link ref at the bottom
+
+  The window title bar and the load message both read `A.version`, so they
+  follow automatically. Versions are `MAJOR.MINOR.PATCH`; 1.1.0 was the first
+  public release (everything below it was pre-release development).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
+[![Version](https://img.shields.io/badge/version-1.1.0-4c1?style=flat-square&labelColor=555)](CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/Hr66t25vE7)
 [![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-8A2BE2?style=flat-square&labelColor=555)](https://octowow.st/)
 [![Capy WoW](https://img.shields.io/badge/Capy%20WoW-1.18.1-8B5A2B?style=flat-square&labelColor=555)](https://capycraft.io/)
@@ -239,7 +240,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v0.22.0`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.0`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/Hr66t25vE7)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "0.22.0"
+A.version = "1.1.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)


### PR DESCRIPTION
## Changelog — already exists ✅

`CHANGELOG.md` has been in the repo since v0.21.1 and **already carried this release's changes** (the cancel-all-undercuts button, no-confirm toggle, scan report, flat-1c defaults, and both posting-bug fixes). So nothing was missing — it just needed relabelling for the release.

Going forward it's maintained: the Contributing section asks for an entry, and CLAUDE.md now requires one on every bump.

## Version → 1.1.0

Bumped in **all four** places that carry a version:

| File | What |
|---|---|
| `core/init.lua` | `A.version = "1.1.0"` |
| `Aegis_Exchange.toc` | `## Version: 1.1.0` |
| `README.md` | new version badge **+** the "check the version" line |
| `CHANGELOG.md` | the `1.1.0` entry and its link ref |

The **window title bar** and the **load message** both read `A.version`, so they follow automatically — verified there are no other hardcoded version strings anywhere in the repo.

### On the 0.22.0 → 1.1.0 relabel
This release's work was developed and merged as `0.22.0` but **never tagged as a release**, so I relabelled its changelog entry to `1.1.0` rather than leave two headings describing one release. The `1.1.0` heading notes that everything below it was pre-release development, so the 0.x history still reads sensibly.

If you'd rather keep `0.22.0` as its own historical entry with a separate `1.1.0` above it, say so and I'll split them.

## Guardrail added
CLAUDE.md now carries the **version-bump checklist** itself — all four files, plus the note that the title bar and load message derive from `A.version`. That's the failure mode where the in-game version quietly disagrees with the release, and it's now written down rather than relying on me remembering.

> Harness green; syntax clean across all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_