### PR TITLE
No badge claims to be &quot;Required&quot; (v1.1.1)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.0
+## Version: 1.1.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.1.1]
+
+### Changed
+- **No badge claims to be "Required" any more.** Aegis calls only vanilla 1.12
+  API, so SuperWoW, Nampower, UnitXP_SP3 and ClassicAPI are now **Recommended**
+  (the recommended client setup for these realms) rather than requirements of
+  this addon. **AuctionQueryThrottle** is split out and marked *Recommended for
+  Aegis* — it is the only external thing that changes Aegis's behaviour, and only
+  scan speed. A caption under the badges says so plainly.
+
 ## [1.1.0] — first public release
 
 > Aegis: Exchange is officially released. Everything below 1.1.0 was
@@ -264,4 +274,4 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
-[1.1.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
+[1.1.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,12 +189,20 @@ are done in practice — **imitate the approach, do not copy code blindly**:
 ## README / CHANGELOG upkeep
 
 - **The badge block at the top of `README.md` is maintained by the project
-  owner.** It is two rows, deliberately:
+  owner.** It is grouped deliberately:
   1. Discord (`5865F2`), then the 1.18.1 servers — Octo WoW purple (`8A2BE2`),
      Capy WoW brown (`8B5A2B`).
-  2. The loaders — **Required** in red (`d62728`: SuperWoW, Nampower,
-     UnitXP_SP3) then **Recommended** in orange (`ff8c00`: ClassicAPI,
-     AuctionQueryThrottle). The colour carries the distinction, not the row.
+  2. **AuctionQueryThrottle** alone, green (`4c1`) and labelled "Recommended
+     for Aegis" — it is the ONLY external thing that changes Aegis's behaviour
+     (scan speed).
+  3. The rest of the realm setup in orange (`ff8c00`): SuperWoW, Nampower,
+     UnitXP_SP3, ClassicAPI — all **Recommended**, followed by a `<sub>` caption
+     saying Aegis needs none of them.
+
+  **Nothing is labelled "Required".** Aegis calls only vanilla 1.12 API; a
+  grep of `core/` and `ui/` finds no SuperWoW / Nampower / UnitXP_SP3 /
+  ClassicAPI calls. Do not reinstate a Required badge without a code change
+  that actually depends on one.
 
   There is deliberately **no pfUI badge** — pfUI is optional, and the "Using
   pfUI?" section says so instead. Do not re-add it.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,21 @@
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
-[![Version](https://img.shields.io/badge/version-1.1.0-4c1?style=flat-square&labelColor=555)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.1.1-4c1?style=flat-square&labelColor=555)](CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/Hr66t25vE7)
 [![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-8A2BE2?style=flat-square&labelColor=555)](https://octowow.st/)
 [![Capy WoW](https://img.shields.io/badge/Capy%20WoW-1.18.1-8B5A2B?style=flat-square&labelColor=555)](https://capycraft.io/)
 
-[![SuperWoW](https://img.shields.io/badge/SuperWoW-Required-d62728?style=flat-square&labelColor=555)](https://github.com/balakethelock/SuperWoW)
-[![Nampower](https://img.shields.io/badge/Nampower-Required-d62728?style=flat-square&labelColor=555)](https://github.com/brues-code/nampower)
-[![UnitXP_SP3](https://img.shields.io/badge/UnitXP__SP3-Required-d62728?style=flat-square&labelColor=555)](https://codeberg.org/konaka/UnitXP_SP3)
+[![AuctionQueryThrottle](https://img.shields.io/badge/AuctionQueryThrottle-Recommended%20for%20Aegis-4c1?style=flat-square&labelColor=555)](https://github.com/brues-code/AuctionQueryThrottle)
+
+[![SuperWoW](https://img.shields.io/badge/SuperWoW-Recommended-ff8c00?style=flat-square&labelColor=555)](https://github.com/balakethelock/SuperWoW)
+[![Nampower](https://img.shields.io/badge/Nampower-Recommended-ff8c00?style=flat-square&labelColor=555)](https://github.com/brues-code/nampower)
+[![UnitXP_SP3](https://img.shields.io/badge/UnitXP__SP3-Recommended-ff8c00?style=flat-square&labelColor=555)](https://codeberg.org/konaka/UnitXP_SP3)
 [![ClassicAPI](https://img.shields.io/badge/ClassicAPI-Recommended-ff8c00?style=flat-square&labelColor=555)](https://github.com/brues-code/ClassicAPI)
-[![AuctionQueryThrottle](https://img.shields.io/badge/AuctionQueryThrottle-Recommended-ff8c00?style=flat-square&labelColor=555)](https://github.com/brues-code/AuctionQueryThrottle)
+
+<sub>**Aegis needs none of these** — it calls only vanilla 1.12 API.
+**AuctionQueryThrottle** is the one that changes anything here (scan speed);
+the rest are the recommended client setup for these realms.</sub>
 
 The stock 1.12 auction house is three text boxes and a prayer. Aegis replaces it
 with a window that actually knows what things are worth — what you should charge,
@@ -201,11 +206,11 @@ numbers, % colours, and profit estimates fill in as you go.
     is there if you ever want the old fixed floor back.
 - **Mail sale-tracking is enUS-only** right now (it matches "Auction successful:").
 - **What Aegis itself needs: nothing but the client.** It calls only vanilla 1.12
-  API. The loader badges above describe the recommended setup for these realms
-  (and the wider Aegis addon series) — Aegis: Exchange does not call SuperWoW,
-  Nampower or UnitXP_SP3, and runs fine without them.
-  [AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle) is
-  the one that changes anything here, and only how fast scans go.
+  API — no SuperWoW, Nampower, UnitXP_SP3 or ClassicAPI calls anywhere in the
+  source, and it runs fine without them. Those are the recommended setup for
+  these realms (and the wider Aegis addon series), not dependencies of this
+  addon. [AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle)
+  is the only one that changes anything here, and only how fast scans go.
 
 ---
 
@@ -240,7 +245,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.0`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.1`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/Hr66t25vE7)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.0"
+A.version = "1.1.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)


### PR DESCRIPTION
## Summary

You're right — labelling those "Required" was simply wrong. A grep of `core/` and `ui/` finds **no** SuperWoW, Nampower, UnitXP_SP3 or ClassicAPI calls anywhere; Aegis uses only vanilla 1.12 API.

I went with **Recommended rather than removal**, because they genuinely *are* the recommended client setup for these realms — that's useful to a reader, it just isn't a dependency of this addon. Removing them would lose real information; mislabelling them was the actual problem.

### The new arrangement

**AuctionQueryThrottle** gets its own row, green, labelled **"Recommended for Aegis"** — it's the one external thing that changes Aegis's behaviour (and only scan speed).

**SuperWoW · Nampower · UnitXP_SP3 · ClassicAPI** sit together in orange as plain **Recommended**, with a caption directly beneath:

> **Aegis needs none of these** — it calls only vanilla 1.12 API. **AuctionQueryThrottle** is the one that changes anything here (scan speed); the rest are the recommended client setup for these realms.

So the distinction is carried three ways — the label, the colour, and the caption — rather than relying on a reader inferring it.

Also fixed: the "honest notes" entry now names **ClassicAPI** too (I'd omitted it).

### Guardrail
`CLAUDE.md` now records that **nothing is Required**, and that a Required badge must not be reinstated without a code change that actually depends on one — so this doesn't quietly regress.

> Version **1.1.1**, keeping the badge, `.toc`, `A.version` and CHANGELOG in step per the checklist. Harness green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_