### PR TITLE
Docs: follow through on the owner's README badge changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ printed in the window title bar — quote it in bug reports.
 ## [1.1.1]
 
 ### Changed
-- **No badge claims to be "Required" any more.** Aegis calls only vanilla 1.12
-  API, so SuperWoW, Nampower, UnitXP_SP3 and ClassicAPI are now **Recommended**
-  (the recommended client setup for these realms) rather than requirements of
-  this addon. **AuctionQueryThrottle** is split out and marked *Recommended for
-  Aegis* — it is the only external thing that changes Aegis's behaviour, and only
-  scan speed. A caption under the badges says so plainly.
+- **Nothing claims to be "Required" any more, and the loader badges are gone.**
+  Aegis calls only vanilla 1.12 API, so the SuperWoW / Nampower / UnitXP_SP3 /
+  ClassicAPI badges were removed rather than left implying a relationship with
+  this addon. **AuctionQueryThrottle** stands alone as *Highly Recommended* — the
+  only external thing that changes Aegis's behaviour, and only scan speed — with
+  a caption stating that Aegis needs no mods or DLLs.
+- Added a **Client** badge (WoW 1.12 vanilla); the version badge was dropped, so
+  the version now lives in the `.toc` and the in-game title bar.
 
 ## [1.1.0] — first public release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,17 +192,20 @@ are done in practice — **imitate the approach, do not copy code blindly**:
   owner.** It is grouped deliberately:
   1. Discord (`5865F2`), then the 1.18.1 servers — Octo WoW purple (`8A2BE2`),
      Capy WoW brown (`8B5A2B`).
-  2. **AuctionQueryThrottle** alone, green (`4c1`) and labelled "Recommended
-     for Aegis" — it is the ONLY external thing that changes Aegis's behaviour
-     (scan speed).
-  3. The rest of the realm setup in orange (`ff8c00`): SuperWoW, Nampower,
-     UnitXP_SP3, ClassicAPI — all **Recommended**, followed by a `<sub>` caption
-     saying Aegis needs none of them.
+     Also a **Client** badge (`c79c6e`, WoW 1.12 vanilla).
+  2. **AuctionQueryThrottle** alone, orange (`ff8c00`), labelled "Highly
+     Recommended" — it is the ONLY external thing that changes Aegis's behaviour
+     (scan speed) — followed by a `<sub>` caption saying Aegis needs no mods or
+     DLLs.
 
-  **Nothing is labelled "Required".** Aegis calls only vanilla 1.12 API; a
-  grep of `core/` and `ui/` finds no SuperWoW / Nampower / UnitXP_SP3 /
-  ClassicAPI calls. Do not reinstate a Required badge without a code change
-  that actually depends on one.
+  **Nothing is Required, and the loader badges were deliberately REMOVED.**
+  SuperWoW, Nampower, UnitXP_SP3 and ClassicAPI badges used to sit here; a grep
+  of `core/` and `ui/` finds no calls to any of them, so the owner removed them
+  rather than imply a relationship. Do not re-add them, and do not reinstate a
+  "Required" badge, without a code change that actually depends on one.
+
+  There is **no version badge** — the version lives in the `.toc` / `A.version`
+  and the in-game title bar.
 
   There is deliberately **no pfUI badge** — pfUI is optional, and the "Using
   pfUI?" section says so instead. Do not re-add it.
@@ -219,7 +222,8 @@ are done in practice — **imitate the approach, do not copy code blindly**:
   stops matching the release:
   1. `core/init.lua` — `A.version`
   2. `Aegis_Exchange.toc` — `## Version:`
-  3. `README.md` — the version badge **and** the "Check the version" line
+  3. `README.md` — the "Check the version" line in "Something broken?"
+     (there is no version badge; do not add one back)
   4. `CHANGELOG.md` — a new entry plus the link ref at the bottom
 
   The window title bar and the load message both read `A.version`, so they

--- a/README.md
+++ b/README.md
@@ -202,10 +202,9 @@ numbers, % colours, and profit estimates fill in as you go.
 - **Mail sale-tracking is enUS-only** right now (it matches "Auction successful:").
 - **What Aegis itself needs: nothing but the client.** It calls only vanilla 1.12
   API — no SuperWoW, Nampower, UnitXP_SP3 or ClassicAPI calls anywhere in the
-  source, and it runs fine without them. Those are the recommended setup for
-  these realms (and the wider Aegis addon series), not dependencies of this
-  addon. [AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle)
-  is the only one that changes anything here, and only how fast scans go.
+  source, so it runs fine without any of them.
+  [AuctionQueryThrottle](https://github.com/brues-code/AuctionQueryThrottle) is
+  the only external thing that changes anything here, and only how fast scans go.
 
 ---
 


### PR DESCRIPTION
Docs only — no Lua touched, no version bump, `/reload`-safe (nothing to reload).

You changed the badge block yourself in four commits on `main`:

| Commit | Change |
|---|---|
| `39cc596` | Version badge → **Client** badge (`WoW 1.12 (vanilla)`, `c79c6e`) |
| `148b755` | AuctionQueryThrottle: green *Recommended for Aegis* → orange **Highly Recommended** |
| `aaf5d3b` | **Removed** the SuperWoW / Nampower / UnitXP_SP3 / ClassicAPI badges; caption rewritten to "Aegis needs no mods or .dll" |
| `6f63620` | Grammar fix in that caption |

So on the loaders you went with **removal**, not "Recommended". This PR makes the rest of the repo agree with that.

### README.md
The "A few honest notes" entry still said those loaders "are the recommended setup for these realms (and the wider Aegis addon series), not dependencies of this addon" — that sentence only made sense while the badges were visible. Trimmed to the part that still stands: Aegis needs nothing but the client, and AuctionQueryThrottle is the only external thing that changes anything (scan speed).

The badge block itself is untouched.

### CLAUDE.md
The upkeep section described the badge block as it *used* to be, which is the real risk here — a future edit could have "restored" the loader badges in good faith. It now records:

- the Client badge and AQT's orange *Highly Recommended*
- that the loader badges were removed **deliberately**, with the reason (no calls to any of them in `core/` or `ui/`), and must not be re-added without a code change that depends on one
- that there is **no version badge**

Also corrected step 3 of the four-place version-bump checklist, which still pointed at the version badge. It now points at the "Check the version" line in *Something broken?* only.

### CHANGELOG.md
The 1.1.1 entry claimed the loaders were "now **Recommended**" — superseded by the removal. Rewritten to the final state, plus the Client badge and the dropped version badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_