### PR TITLE
v1.1.2 — scrollable Aegis settings, profession-window alignment

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.1
+## Version: 1.1.2
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.1.2]
+
+### Fixed
+- **The Aegis tab's settings no longer run off the bottom of the window.**
+  Everything below the tip line now sits in a scrollable region with its own
+  bar (mouse wheel works too); the bar hides itself when it isn't needed. The
+  settings block had simply outgrown the panel — *Price data / Clear price
+  data* was clipped by the window edge with no way to reach it.
+- **"Add to Aegis" and the profit lines are aligned on the stock profession
+  window.** They were anchored to the frame's own bottom-right corner, which on
+  the unskinned window is out under its thick ornate border art — so the whole
+  cluster sat outside the panel. pfUI's border is a hairline, which is why this
+  only ever looked right when skinned. They now anchor to the window's own
+  Exit button, which is inside the content area in both UIs.
+
+### Changed
+- The Discord invite moved to `hsgPTNkSX` across all five places in the README.
+
 ## [1.1.1]
 
 ### Changed
@@ -276,4 +294,5 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.1.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,27 +204,33 @@ are done in practice — **imitate the approach, do not copy code blindly**:
   rather than imply a relationship. Do not re-add them, and do not reinstate a
   "Required" badge, without a code change that actually depends on one.
 
-  There is **no version badge** — the version lives in the `.toc` / `A.version`
-  and the in-game title bar.
+  There is **no version badge** — but the **H1 carries the version**
+  (`# Aegis: Exchange (v1.1.2)`), so it is a bump site. See the checklist below.
 
   There is deliberately **no pfUI badge** — pfUI is optional, and the "Using
   pfUI?" section says so instead. Do not re-add it.
 
   Keep the shields.io style (`flat-square`, `labelColor=555`) when adding to it,
   and do not reorder, re-row or restyle it unasked.
-- **One Discord invite, used everywhere: `https://discord.gg/Hr66t25vE7`.** It
+- **One Discord invite, used everywhere: `https://discord.gg/hsgPTNkSX`.** It
   appears in five places — the badge, the intro line, "Something broken?",
   Contributing and the footer. Change all five together or none, and never
   swap it for one pasted in chat without confirming it is current.
+  - This invite has now changed twice, and **both times only the badge got
+    updated**, leaving the other four pointing at a dead invite. When you see
+    the badge disagree with the body links, the badge is the new one — but
+    confirm before propagating, because "the badge is stale instead" is
+    equally possible and a wrong guess breaks every link in the file.
 - Every version bump gets a `CHANGELOG.md` entry. Mark a release **restart**
   when it adds a new `.lua` file to the `.toc`.
-- **A version bump touches FOUR places** — miss one and the in-game version
+- **A version bump touches FIVE places** — miss one and the in-game version
   stops matching the release:
   1. `core/init.lua` — `A.version`
   2. `Aegis_Exchange.toc` — `## Version:`
-  3. `README.md` — the "Check the version" line in "Something broken?"
-     (there is no version badge; do not add one back)
-  4. `CHANGELOG.md` — a new entry plus the link ref at the bottom
+  3. `README.md` — the **H1**: `# Aegis: Exchange (vX.Y.Z)`
+  4. `README.md` — the "Check the version" line in "Something broken?"
+     (there is still no version *badge*; do not add one back)
+  5. `CHANGELOG.md` — a new entry plus the link ref at the bottom
 
   The window title bar and the load message both read `A.version`, so they
   follow automatically. Versions are `MAJOR.MINOR.PATCH`; 1.1.0 was the first

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.1.1)
+# Aegis: Exchange (v1.1.2)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -35,7 +35,7 @@ made this week.
 >
 > It's a DLL, not an addon, and it needs the VanillaFixes loader.
 
-**[💬 Join the Discord](https://discord.gg/Hr66t25vE7)** for help, bug reports,
+**[💬 Join the Discord](https://discord.gg/hsgPTNkSX)** for help, bug reports,
 and feature ideas.
 
 ---
@@ -239,9 +239,9 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.1`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.2`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
-3. Tell us on **[Discord](https://discord.gg/Hr66t25vE7)** or open an
+3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots
    help enormously, especially for anything layout-related.
 
@@ -251,7 +251,7 @@ Recent changes are in [CHANGELOG.md](CHANGELOG.md).
 
 ## Contributing
 
-PRs welcome — come say hi on **[Discord](https://discord.gg/Hr66t25vE7)** first
+PRs welcome — come say hi on **[Discord](https://discord.gg/hsgPTNkSX)** first
 if you're planning something big.
 
 Three requests:
@@ -270,7 +270,7 @@ MIT — see [LICENSE](LICENSE).
 
 <div align="center">
 
-**[💬 Discord](https://discord.gg/Hr66t25vE7)** · **[📜 Changelog](CHANGELOG.md)** · **[🐛 Issues](https://github.com/Torchlite-bit/Aegis_Exchange/issues)**
+**[💬 Discord](https://discord.gg/hsgPTNkSX)** · **[📜 Changelog](CHANGELOG.md)** · **[🐛 Issues](https://github.com/Torchlite-bit/Aegis_Exchange/issues)**
 
 *Aegis: Exchange is part of the Aegis addon series. Happy flipping.* ⚔️
 

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.1"
+A.version = "1.1.2"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -345,7 +345,73 @@ function ui.BuildWindow()
         .. " Scan Selected runs a fast targeted scan.")
     tip:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
 
-    ui.BuildAegisSettings(scanPanel, tip)
+    -- The settings block lives in a REAL ScrollFrame, not a FauxScrollFrame.
+    -- Every other tab virtualises fixed-height rows, which is what
+    -- FauxScrollFrame is for; settings are heterogeneous widgets that can't be
+    -- recycled into rows. A ScrollFrame is also the only 1.12 widget that
+    -- CLIPS its child -- this client has no SetClipsChildren -- so it's the
+    -- only way to keep overflow inside the window instead of spilling past the
+    -- bottom edge, which is what 1.1.1 did once the pacing and confirm-cancel
+    -- rows were added.
+    local SB_W = 16
+    local scroll = CreateFrame("ScrollFrame", "AegisExchangeAegisScroll",
+        scanPanel)
+    scroll:SetPoint("TOPLEFT", tip, "BOTTOMLEFT", 0, -8)
+    scroll:SetPoint("BOTTOMRIGHT", scanPanel, "BOTTOMRIGHT", -(SB_W + 10), 6)
+    ui.aegisScroll = scroll
+
+    local scrollChild = CreateFrame("Frame", "AegisExchangeAegisScrollChild",
+        scroll)
+    scrollChild:SetWidth(600)
+    scrollChild:SetHeight(300)
+    scroll:SetScrollChild(scrollChild)
+    ui.aegisScrollChild = scrollChild
+
+    -- Hand-built from a base Slider rather than inheriting a scroll template:
+    -- Slider is a primitive widget type that always exists, so there's no
+    -- "Couldn't find inherited node" risk from guessing a 1.12 template name
+    -- (the AuctionFrameTab lesson), and it matches the Aegis palette. Marked
+    -- aegisNoSkin because pfUI's SkinScrollbar reaches for the up/down buttons
+    -- a template would have supplied.
+    local sb = CreateFrame("Slider", "AegisExchangeAegisScrollBar", scanPanel)
+    sb.aegisNoSkin = true
+    sb:SetWidth(SB_W)
+    sb:SetPoint("TOPLEFT", scroll, "TOPRIGHT", 8, 0)
+    sb:SetPoint("BOTTOMLEFT", scroll, "BOTTOMRIGHT", 8, 0)
+    sb:SetOrientation("VERTICAL")
+    sb:SetMinMaxValues(0, 0)
+    sb:SetValue(0)
+    sb:SetValueStep(1)
+    sb:SetBackdrop({
+        bgFile = "Interface\\Buttons\\UI-SliderBar-Background",
+        edgeFile = "Interface\\Buttons\\UI-SliderBar-Border",
+        tile = true, tileSize = 8, edgeSize = 8,
+        insets = { left = 3, right = 3, top = 6, bottom = 6 },
+    })
+    local thumb = sb:CreateTexture(nil, "OVERLAY")
+    thumb:SetTexture("Interface\\Buttons\\UI-SliderBar-Button-Vertical")
+    thumb:SetWidth(SB_W)
+    thumb:SetHeight(24)
+    sb:SetThumbTexture(thumb)
+    -- 1.12: the scripted widget is the global `this`, never a self argument.
+    sb:SetScript("OnValueChanged", function()
+        scroll:SetVerticalScroll(this:GetValue())
+    end)
+    sb:Hide()
+    ui.aegisScrollBar = sb
+
+    -- Wheel over the settings area scrolls it. arg1 is the wheel delta global
+    -- (+1 up / -1 down) on this client.
+    scroll:EnableMouseWheel(true)
+    scroll:SetScript("OnMouseWheel", function()
+        local _, maxV = sb:GetMinMaxValues()
+        local v = sb:GetValue() - (arg1 * 24)
+        if v < 0 then v = 0 end
+        if v > maxV then v = maxV end
+        sb:SetValue(v)
+    end)
+
+    ui.BuildAegisSettings(scrollChild, nil)
     ui.BuildSellTab()
     ui.BuildBuyTab()
     ui.BuildCraftTab()
@@ -394,10 +460,74 @@ StaticPopupDialogs["AEGIS_EXCHANGE_CLEARDB"] = {
     timeout = 0, whileDead = 1, hideOnEscape = 1,
 }
 
+-- Distance from a frame's top edge to the lowest edge of anything inside it.
+-- Measured rather than hardcoded so that adding a setting later can't silently
+-- clip again. Returns nil until the frame has actually been laid out (GetTop
+-- is nil while hidden), so callers keep the last good value.
+local function ContentExtent(frame)
+    local top = frame:GetTop()
+    if not top then return nil end
+    local lowest = top
+    local function sweep(list)
+        local i = 1
+        local n = table.getn(list)
+        while i <= n do
+            local o = list[i]
+            if o and o.GetBottom then
+                local b = o:GetBottom()
+                if b and b < lowest then lowest = b end
+            end
+            i = i + 1
+        end
+    end
+    -- 1.12 returns these as multiple values; the table constructor captures
+    -- them without needing select(), which doesn't exist on Lua 5.0.
+    sweep({ frame:GetChildren() })
+    sweep({ frame:GetRegions() })
+    return top - lowest
+end
+
+-- Fit the Aegis tab's scroll child to its content and update the bar's range.
+-- Hides the bar entirely when everything already fits.
+function ui.UpdateAegisScroll()
+    local scroll = ui.aegisScroll
+    local child = ui.aegisScrollChild
+    local sb = ui.aegisScrollBar
+    if not scroll or not child or not sb then return end
+
+    local w = scroll:GetWidth()
+    if w and w > 0 then child:SetWidth(w) end
+
+    local measured = ContentExtent(child)
+    if measured then
+        ui.aegisContentH = measured + 10   -- breathing room under the last row
+    end
+    local contentH = ui.aegisContentH or 300
+    child:SetHeight(contentH)
+
+    local viewH = scroll:GetHeight() or 0
+    local maxScroll = contentH - viewH
+    if maxScroll < 1 then
+        sb:SetMinMaxValues(0, 0)
+        sb:SetValue(0)
+        sb:Hide()
+    else
+        sb:SetMinMaxValues(0, maxScroll)
+        if sb:GetValue() > maxScroll then sb:SetValue(maxScroll) end
+        sb:Show()
+    end
+end
+
+-- `anchorAbove` is optional: when the settings sit in the Aegis tab's scroll
+-- child they start at its top instead of hanging off the scan controls.
 function ui.BuildAegisSettings(panel, anchorAbove)
     -- Section header under the scan controls.
     local hdr = panel:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    hdr:SetPoint("TOPLEFT", anchorAbove, "BOTTOMLEFT", 0, -18)
+    if anchorAbove then
+        hdr:SetPoint("TOPLEFT", anchorAbove, "BOTTOMLEFT", 0, -18)
+    else
+        hdr:SetPoint("TOPLEFT", panel, "TOPLEFT", 0, -4)
+    end
     hdr:SetText("Settings")
     hdr:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
 
@@ -736,6 +866,11 @@ function ui.RefreshSettings()
             ui.setThrottleInfo:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
         end
     end
+
+    -- Content can change height (the pacing readout wraps differently), so
+    -- re-measure whenever we repaint. SelectSubTab already routes the Scan tab
+    -- through here, which is the moment the panel becomes measurable.
+    ui.UpdateAegisScroll()
 end
 
 -- ---------------------------------------------------------------------------
@@ -2300,14 +2435,32 @@ end
 
 -- Put an "Add to Aegis" button on a profession window, anchored to its close
 -- button. Save-original-and-replace only: no secure hooks on 1.12.
-function ui.AttachCraftButton(frame, name)
+function ui.AttachCraftButton(frame, name, anchorNames)
     if not frame or getglobal(name) then return end
     local b = CreateFrame("Button", name, frame, "UIPanelButtonTemplate")
     b:SetWidth(96); b:SetHeight(20)
-    -- Pin to the frame's BOTTOM-RIGHT, above the Create/Exit buttons. This spot
-    -- is clear in BOTH the stock UI and pfUI (no packed header / corner X to
-    -- fight), and the profit line stacks directly above it.
-    b:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -16, 46)
+    -- Anchor to the window's OWN Exit/Create button, not to the frame corner.
+    -- Same principle as the pfUI header fix: anchor to something that moves
+    -- with the skin. The stock profession window's BOTTOMRIGHT sits out under
+    -- its thick ornate border art, so -16,46 landed the button (and the profit
+    -- lines stacked above it) outside the panel; pfUI's border is a hairline,
+    -- which is why it only ever looked right when skinned. The Exit button is
+    -- inside the content area in both.
+    local anchor = nil
+    if anchorNames then
+        local i = 1
+        while i <= table.getn(anchorNames) and not anchor do
+            anchor = getglobal(anchorNames[i])
+            i = i + 1
+        end
+    end
+    if anchor then
+        b:SetPoint("BOTTOMRIGHT", anchor, "TOPRIGHT", 0, 8)
+    else
+        -- Unknown window layout: fall back well inside the frame rather than
+        -- on top of its border.
+        b:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -40, 60)
+    end
     b:SetText("Add to Aegis")
     b:SetScript("OnClick", function() ui.CraftCapture() end)
     if A.skin then A.skin.ApplyExternal() end
@@ -2329,7 +2482,7 @@ function ui.AttachProfLine(frame, btnName, key)
     if btn then
         sub:SetPoint("BOTTOMRIGHT", btn, "TOPRIGHT", 0, 6)
     else
-        sub:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -16, 74)
+        sub:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -40, 88)
     end
     sub:SetJustifyH("RIGHT")
     sub:SetWidth(210)
@@ -2399,12 +2552,14 @@ end
 
 function ui.HookProfessionFrames()
     if TradeSkillFrame then
-        ui.AttachCraftButton(TradeSkillFrame, "AegisExchangeAddTradeSkillButton")
+        ui.AttachCraftButton(TradeSkillFrame, "AegisExchangeAddTradeSkillButton",
+            { "TradeSkillCancelButton", "TradeSkillCreateButton" })
         ui.AttachProfLine(TradeSkillFrame,
             "AegisExchangeAddTradeSkillButton", "tradeskill")
     end
     if CraftFrame then
-        ui.AttachCraftButton(CraftFrame, "AegisExchangeAddCraftButton")
+        ui.AttachCraftButton(CraftFrame, "AegisExchangeAddCraftButton",
+            { "CraftCancelButton", "CraftCreateButton" })
         ui.AttachProfLine(CraftFrame, "AegisExchangeAddCraftButton", "craft")
     end
     if ui.profPoller then ui.profPoller:Show() end


### PR DESCRIPTION
Both items from your 1.1.2 list, plus README maintenance. `/reload`-safe — no new `.lua` file, so no client restart needed.

## 1. Aegis tab now scrolls

Your first screenshot shows *Price data: 5486 item(s) recorded* / **Clear price data** clipped by the window's bottom edge, unreachable. The settings block had simply outgrown the panel once scan pacing and confirm-cancel were added.

Everything below the tip line now lives in a scroll region with its own bar and mouse-wheel support. The bar hides itself when the content already fits, so nothing changes visually until it needs to.

**Why a real `ScrollFrame` and not a `FauxScrollFrame`** — every other tab uses Faux, so this is a deliberate departure:

- Faux virtualises **fixed-height rows**; settings are heterogeneous widgets that can't be recycled into rows.
- A `ScrollFrame` is the only 1.12 widget that **clips** its child. There is no `SetClipsChildren` on this client, so it's the only way to keep overflow inside the window rather than spilling past the edge.

The bar is **hand-built from a base `Slider`** rather than inheriting a scroll template — `Slider` is a primitive type that always exists, so there's no *"Couldn't find inherited node"* risk from guessing a 1.12 template name (the `AuctionFrameTab` lesson), and it matches the Aegis palette. It's flagged `aegisNoSkin` because pfUI's `SkinScrollbar` reaches for the up/down buttons a template would have supplied.

Content height is **measured** from the laid-out widgets, not hardcoded, so adding a setting later can't silently clip again.

## 2. Profession window alignment

Your 2nd and 3rd screenshots: the cluster sits neatly inside under pfUI, and hangs outside the panel on the default UI.

**Cause:** the button was anchored to the frame's own `BOTTOMRIGHT` at `-16, 46`. On the stock window that point is out under the thick ornate border art; pfUI's border is a hairline, which is why it only ever looked right when skinned. Same class of bug as the pfUI header fix in 0.20.2 — *anchor to something that moves with the skin, not to a frame edge*.

**Fix:** anchor to the window's own **Exit** button, which is inside the content area in both UIs, with a well-inset fallback if the layout is unrecognised. The profit lines already stacked off the button, so they follow for free.

## 3. README maintenance

Your `18a802f` moved the Discord **badge** to `hsgPTNkSX` but left the other four links on `Hr66t25vE7`. That's the same "only the badge got updated" slip as the previous invite change, so I confirmed with you which was live before propagating rather than guessing — and CLAUDE.md now records the pattern and that the badge is the tell.

Your `8813a14` put the version in the H1, which makes it a **new bump site**. The version-bump checklist in CLAUDE.md is now **five** places, not four:

1. `core/init.lua` — `A.version`
2. `Aegis_Exchange.toc` — `## Version:`
3. `README.md` — the H1
4. `README.md` — the "Check the version" line
5. `CHANGELOG.md` — entry + link ref

> One note: your message said *"bump it to v1.1.0"*, but the repo was already at 1.1.1 and your work items said "build 1.1.2" — so I went forward to **1.1.2**. Say the word if you meant something else.

## Verification

- `luac5.1 -p` clean on all 10 files
- 1.12 compliance re-scanned on the added lines: no `string.match`/`gmatch`, no `#`, no `%` operator, no `select()`, no `_G`, no secure hooks; uses `table.getn` and the `this`/`arg1` event globals
- The simulated 1.12 harness passes, extended with the `ScrollFrame`/`Slider`/geometry surface it was missing
- **Both fixes have regression tests that fail when reverted** — verified by actually reverting each one, not assumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_