### PR TITLE
v1.1.3 — inset "Add to Aegis" off the profession window's edge

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.2
+## Version: 1.1.3
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.1.3]
+
+### Fixed
+- **"Add to Aegis" no longer clips the profession window's right edge.** It was
+  anchored flush with the Exit button's right edge, but the button is wider
+  than Exit and its border art overhangs its logical bounds, so it overlapped
+  the frame in both the stock UI and pfUI. Now inset 10px; the profit lines
+  stack off the button, so they move with it.
+
 ## [1.1.2]
 
 ### Fixed
@@ -294,5 +303,6 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.1.3]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.1.2)
+# Aegis: Exchange (v1.1.3)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -239,7 +239,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.2`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.3`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.2"
+A.version = "1.1.3"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -2455,7 +2455,12 @@ function ui.AttachCraftButton(frame, name, anchorNames)
         end
     end
     if anchor then
-        b:SetPoint("BOTTOMRIGHT", anchor, "TOPRIGHT", 0, 8)
+        -- Pulled 10px LEFT of the Exit button's right edge rather than flush
+        -- with it. "Add to Aegis" is wider than Exit, and its template's border
+        -- art overhangs its logical bounds, so a flush right edge clipped the
+        -- window frame in both UIs. The profit lines stack off this button, so
+        -- they inset with it.
+        b:SetPoint("BOTTOMRIGHT", anchor, "TOPRIGHT", -10, 8)
     else
         -- Unknown window layout: fall back well inside the frame rather than
         -- on top of its border.


### PR DESCRIPTION
Follow-up to the 1.1.2 anchor fix. One-line change plus the version bump. `/reload`-safe.

## What was still wrong

Moving the cluster onto the Exit button (1.1.2) put it inside the content area, but I anchored its right edge **flush** with Exit's — `x = 0`. That still clipped, in both UIs:

- **"Add to Aegis" is wider than Exit** (96px vs Exit's width), so a shared right edge isn't a shared silhouette.
- `UIPanelButtonTemplate`'s **border art overhangs** the button's logical bounds, so even a perfectly-aligned edge paints a few pixels past it.

Net effect: the rightmost sliver landed on the window border, exactly as your screenshots show.

## Fix

Inset the anchor by 10px instead of 0:

```lua
b:SetPoint("BOTTOMRIGHT", anchor, "TOPRIGHT", -10, 8)
```

The profit lines stack off this button, so `Aegis: Loss 42c` / `mats 80c sells 40c` move with it — both stop clipping together, which is what you predicted.

## Verification

- `luac5.1 -p` clean on all 10 files
- Harness passes, and gained an assertion that the offset is **negative** — so a future edit can't quietly put it back flush. Confirmed it fails at `x=0` with `ASSERT: Add to Aegis is inset left of Exit, not flush, got x=0`

Version bumped across all five places (`init.lua`, `.toc`, README H1, README "Check the version" line, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_