### PR TITLE
v1.1.4 — clear out the last traces of the shell stage

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.3
+## Version: 1.1.4
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.1.4]
+
+> Internal cleanup only — no user-visible change. Bumped so an in-game bug
+> report still names the build it came from.
+
+### Removed
+- Dead placeholder code in the sub-tab loop. It built a centered "coming soon"
+  label for any tab not in a hardcoded exclusion list — but that list had grown
+  to contain every entry in `SUBTABS`, so the branch had been unreachable since
+  the last placeholder tab was filled in 0.15.0.
+
+### Changed
+- `ui/frame.lua`'s header still described the file as "Stage A: shell only"
+  with "empty labels" for panels and scanning "in later stages". All six tabs
+  have been real since 0.15.0; the header now describes the actual layout.
+- `AegisExchangeSwapButton` — the "Aegis UI" button on the stock auction house
+  — is now commented as the deliberate, single exception to "nothing is
+  parented to AuctionFrame", so it doesn't read as leftover overlay code.
+- `CLAUDE.md`'s project layout was missing `core/buy.lua`, `ui/skin.lua` and
+  `pfui/`, and its load order omitted `buy` and `skin`.
+
 ## [1.1.3]
 
 ### Fixed
@@ -303,6 +324,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.1.4]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.3]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,19 +154,35 @@ Aegis_Exchange/
   Aegis_Exchange.toc     -- Interface 11200; declares SavedVariables + load order
   core/init.lua          -- namespace (AegisExchange) + event dispatcher + OnLoad queue
   core/util.lua          -- Lua 5.0 safe helpers (money fmt/parse, split, table utils)
-  core/db.lua            -- SavedVariables price DB (daily-min + weighted-median market)
+  core/db.lua            -- SavedVariables price DB (daily-min + weighted-median
+                         -- market), settings, ledger, vendor prices
   core/scan.lua          -- page-by-page auction scanner state machine
-  core/sell.lua          -- posting engine (StartAuction wrap + deposit/cap/cut)
-  ui/frame.lua           -- standalone Aegis window (replaces the AH) + sub-tabs
+  core/sell.lua          -- posting engine (StartAuction wrap + deposit/cap/cut),
+                         -- owned auctions, vendor list
+  core/buy.lua           -- search/buy engine + shopping lists; also defines the
+                         -- A.craft namespace (recipe capture + profit maths)
+  ui/frame.lua           -- standalone Aegis window (replaces the AH) + all six
+                         -- sub-tabs; ~5k lines, the bulk of the addon
+  ui/skin.lua            -- OPTIONAL pfUI restyling; every call pcall-guarded so
+                         -- a pfUI API change can only cost us the default look
   ui/tooltip.lua         -- GameTooltip price lines (save/replace hooks)
+  pfui/Aegis_Exchange.lua-- drop-in for pfUI-addonskinner users. NOT in the .toc
+                         -- and NOT loaded by us; it just calls A.skin.Apply()
   design/                -- VISUAL REFERENCE ONLY (mockup renders + source);
                          -- never ported to Lua verbatim, NEVER in the .toc
   CLAUDE.md              -- this file
 ```
 
 Load order is fixed by the `.toc`: `init` → `util` → `db` → `scan` → `sell` →
-`frame` → `tooltip`. `init.lua` must load first (it creates the namespace and
-dispatcher); `sell` before `frame` because the Sell tab drives `A.sell`.
+`buy` → `frame` → `skin` → `tooltip`. `init.lua` must load first (it creates
+the namespace and dispatcher); `util` second (every other module takes a
+file-scope `local util = A.util`); `sell` and `buy` before `frame` because the
+tabs drive `A.sell` / `A.buy` / `A.craft`. `skin` and `tooltip` are only
+reached at runtime, so their position is not load-critical.
+
+**Adding a `.lua` file means editing the `.toc` — and that needs a FULL client
+restart, not `/reload`.** 1.12 reads the file list at startup. Mark such a
+release **restart** in `CHANGELOG.md`.
 
 The repository root **is** the addon folder: clone/copy it into
 `Interface/AddOns/Aegis_Exchange` so the folder name matches the `.toc`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.1.3)
+# Aegis: Exchange (v1.1.4)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -239,7 +239,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.3`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.4`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.3"
+A.version = "1.1.4"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1,7 +1,7 @@
 -- Aegis: Exchange
 -- ui/frame.lua
 --
--- STANDALONE custom auction window (Stage A: shell only).
+-- STANDALONE custom auction window.
 --
 -- Aegis is its OWN top-level frame parented to UIParent — it does NOT tab onto
 -- or parent to the Blizzard AuctionFrame. When the auction house opens we hide
@@ -11,11 +11,15 @@
 -- because no Blizzard AH frame is visible there are no default widgets, holes,
 -- sort headers, or backgrounds to conflict with.
 --
--- Stage A is skin + lifecycle + sub-tab switching only. Full Scan / Pause /
--- Resume are placeholders (chat messages); the sub-tab panels are empty labels.
--- Scanning, price DB, posting, search, etc. arrive in later stages, rendered
--- into these panels. (The scan/db/tooltip modules are unchanged and still
--- feed item tooltips.)
+-- Layout: BuildWindow() creates the frame, the sub-tab strip and one empty
+-- panel per sub-tab, then hands each panel to its own builder —
+-- BuildBuyTab / BuildSellTab / BuildAuctionsTab / BuildCraftTab /
+-- BuildHistoryTab, plus the scan controls and BuildAegisSettings for the
+-- "Aegis" tab. Every panel is a real tab; none are placeholders.
+--
+-- The one frame here that is NOT parented to our window is
+-- AegisExchangeSwapButton, the "Aegis UI" button we put ON the Blizzard AH so
+-- the hand-off works both ways. See HookAuctionFrame.
 
 local A = AegisExchange
 A.ui = A.ui or {}
@@ -40,8 +44,9 @@ local C = {
 -- Last scan older than this is "stale" and rendered amber.
 local STALE_SECONDS = 24 * 60 * 60
 
--- "Scan" hosts the scanner controls (Full Scan / Pause / Resume / Categories
--- + status and progress); the others are placeholders for later stages.
+-- Sub-tab order, left to right. "Scan" hosts the scanner controls (Full Scan /
+-- Pause / Resume / Stop / Categories + status and progress) and the settings
+-- block; it is displayed as "Aegis" via TAB_LABELS below.
 local SUBTABS = { "Buy", "Sell", "Auctions", "Crafting", "History", "Scan" }
 
 -- Display label per sub-tab (internal keys stay stable). The scan tab also
@@ -217,8 +222,8 @@ function ui.BuildWindow()
     content:SetBackdropBorderColor(C.border[1], C.border[2], C.border[3])
     ui.content = content
 
-    -- One panel per sub-tab, filling the content region. All but Scan are
-    -- placeholders (centered label); Scan hosts the scanner controls below.
+    -- One panel per sub-tab, filling the content region. Each is populated by
+    -- its own Build*Tab function below.
     ui.panels = {}
     i = 1
     while i <= nTabs do
@@ -227,17 +232,6 @@ function ui.BuildWindow()
         panel:SetPoint("TOPLEFT", content, "TOPLEFT", 6, -6)
         panel:SetPoint("BOTTOMRIGHT", content, "BOTTOMRIGHT", -6, 6)
         panel:Hide()
-        -- Every tab is now a real tab (built below); no placeholders remain.
-        if name ~= "Scan" and name ~= "Sell" and name ~= "Buy"
-            and name ~= "Crafting" and name ~= "Auctions"
-            and name ~= "History" then
-            local label = panel:CreateFontString(
-                "AegisExchangePanelLabel" .. name, "OVERLAY",
-                "GameFontNormalLarge")
-            label:SetPoint("CENTER", panel, "CENTER", 0, 0)
-            label:SetText(name)
-            label:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
-        end
         ui.panels[name] = panel
         i = i + 1
     end
@@ -5018,6 +5012,14 @@ function ui.HookAuctionFrame()
 
     -- "Aegis UI" button on the stock AH so the hand-off works both ways.
     -- OpenWindow hides the Blizzard AH session-safely and shows ours.
+    --
+    -- DELIBERATE EXCEPTION to "never parent anything to AuctionFrame": this is
+    -- the ONE frame we hang off the Blizzard window, and it has to be, because
+    -- it must appear on THEIR window while ours is hidden. Parenting it to
+    -- AuctionFrame is what makes it show and hide with the Blizzard AH for
+    -- free. Do not read this as leftover overlay code and remove it -- it is
+    -- the documented return path (README: "Aegis UI button (on the stock AH)").
+    -- Everything else Aegis draws lives under UIParent.
     if not ui.blizSwapBtn then
         local b = CreateFrame("Button", "AegisExchangeSwapButton",
             AuctionFrame, "UIPanelButtonTemplate")


### PR DESCRIPTION
All five audit items. **No behaviour change** — the code removed here could not execute. `/reload`-safe.

| # | Item | Done |
|---|---|---|
| 1 | Rebase off `origin/main` | ✅ Branch restarted from `58304d8` (#54's merge) |
| 2 | Delete dead placeholder branch | ✅ Removed |
| 3 | Fix four stale Stage A comment blocks | ✅ Rewritten |
| 4 | Sync CLAUDE.md project layout | ✅ Three files + load order added |
| 5 | Decide on `AegisExchangeSwapButton` | ✅ **Kept**, documented as the deliberate exception |

## 2 — Dead placeholder branch

Built a centered "coming soon" label for any tab not in a hardcoded exclusion list — but that list had grown to hold **every** entry in `SUBTABS`, so the condition was false by construction. Unreachable since the last placeholder tab was filled in 0.15.0. The comment directly above it already read *"no placeholders remain"*, which was the tell.

## 3 — Stale header comments

`ui/frame.lua` opened with **"Stage A: shell only"** and went on to claim Full Scan / Pause / Resume are placeholders posting chat messages, the sub-tab panels are empty labels, and that scanning, the price DB, posting and search *"arrive in later stages"*.

All six tabs have been real since 0.15.0. Anyone reading the file top-down was being told the addon is a skeleton. Replaced with a description of the actual layout and where each panel gets populated.

## 5 — `AegisExchangeSwapButton`: kept

Went with keeping it. It's the only frame parented to `AuctionFrame`, and it has to be — it appears on **their** window while ours is hidden, and the parenting is what makes it show/hide with the Blizzard AH for free. Reparenting to `UIParent` would mean manually mirroring `AuctionFrame`'s visibility for no gain.

The risk was never the code, it was that it *reads* like leftover overlay code. The comment now says so explicitly and points at the README line documenting the return path, so a future cleanup pass doesn't "helpfully" delete it.

## 4 — CLAUDE.md

Layout was three files behind (`core/buy.lua`, `ui/skin.lua`, `pfui/`) and the load order omitted `buy` and `skin`. Also recorded *why* the order is what it is (`util` second because every module takes a file-scope `local util = A.util`; `sell`/`buy` before `frame` because the tabs drive them), and that adding a `.lua` file needs a full client restart rather than `/reload`.

## Verification

- `luac5.1 -p` clean on all 10 files; harness green
- Harness gained a check that all six panels are **created and registered in `ui.panels`** — the registry `SelectSubTab` actually drives. Worth noting: I first asserted only that the frame global exists, sabotaged the registration to test it, and **it didn't catch it** — the frame is created either way. Both are now asserted, and the registry check fires correctly.

Version bumped across all five places. The CHANGELOG entry is marked internal-only so it doesn't read as a feature release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_