### PR TITLE
v1.1.5 — fix four Sell/Buy bugs (split posting, right-click, tooltips, clipping)

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.4
+## Version: 1.1.5
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.1.5]
+
+### Fixed
+- **"Posted 0 of N. (couldn't assemble a stack)" whenever a stack had to be
+  split.** `SplitContainerItem` is a *server round-trip* on 1.12, but the
+  assembler called `ClickAuctionSellItemButton` in the same frame — firing
+  against a still-empty cursor, so the sell slot never filled, verify failed,
+  and the job burned its retries. This is why posting worked if you manually
+  split the stacks yourself first (that path uses the instant
+  `PickupContainerItem`) and failed every time Aegis had to do the splitting.
+  The assembler now waits for the item to actually reach the cursor before
+  handing it to the sell slot, exiting the moment it lands.
+- **Right-click a bag item to load it into the Sell tab.** It played the default
+  click sound and did nothing. Both right-click paths are now hooked — the stock
+  bag buttons *and* `UseContainerItem`, which is where replacement bag addons
+  (pfUI and friends) land — so the item goes into the sell slot with pricing
+  filled in. Only active while the Aegis window is open on the Sell tab, and
+  only for postable items, so right-click keeps its normal meaning everywhere
+  else.
+- **Hover tooltips on search results.** The Buy, Crafting, Auctions and Sell
+  listing rows had no tooltip. They do now; the browse rows re-verify the
+  auction index first, so a row can never describe someone else's listing after
+  the page shifts.
+- **Long item names no longer overflow the "Your Bags" list.** Names like
+  *Formula: Enchant Shield - Lesser Protection* ran straight out of the list and
+  into the listings table. They're now clipped with an ellipsis. (1.12 has no
+  truncation mode for text — giving a FontString a width makes it *wrap* — so
+  the name is measured and cut instead.)
+- A job whose item was already sitting in the sell slot moved to a phase name
+  nothing handled, and would have hung there instead of posting.
+
 ## [1.1.4]
 
 ### Fixed
@@ -321,6 +352,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.1.5]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.4]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.3]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.1.4)
+# Aegis: Exchange (v1.1.5)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -239,7 +239,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.4`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.5`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.4"
+A.version = "1.1.5"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/sell.lua
+++ b/core/sell.lua
@@ -724,6 +724,11 @@ end
 local ASSEMBLE_DELAY = 0.25
 local POST_DELAY     = 0.45
 local MAX_RETRIES    = 4
+-- How long to wait for a split/pickup to actually reach the cursor before
+-- treating the attempt as lost. SplitContainerItem needs a server round-trip on
+-- 1.12, so this has to tolerate realm latency; the poll exits the instant the
+-- cursor fills, so a fast realm never pays the full budget.
+local CURSOR_TIMEOUT = 2.0
 
 -- Total count of an item across all POSTABLE bag slots.
 function sell.CountInBags(itemId)
@@ -896,7 +901,11 @@ function sell.PostTick(dt)
     if job.phase == "assemble" then
         local it = sell.GetItem()
         if it and it.itemId == job.itemId and it.count == job.stackSize then
-            job.phase = "post"           -- already assembled
+            -- Already assembled (e.g. the user had it slotted). Go straight to
+            -- the phase that fires the auction. This used to say "post", which
+            -- no branch below handles -- the job would sit in a dead state
+            -- forever instead of posting.
+            job.phase = "verify"
             return
         end
         if CursorHasItem() then ClearCursor() end
@@ -918,9 +927,37 @@ function sell.PostTick(dt)
         else
             SplitContainerItem(bag, slot, job.stackSize)   -- part of it
         end
-        ClickAuctionSellItemButton()                   -- cursor -> sell slot
-        job.phase = "verify"
-        job.cool = ASSEMBLE_DELAY
+        -- Do NOT click the sell button in this same tick. PickupContainerItem
+        -- puts the stack on the cursor immediately (client-side), but
+        -- SplitContainerItem needs a SERVER ROUND-TRIP on 1.12 -- so clicking
+        -- now fires against an empty cursor, the sell slot stays empty, verify
+        -- fails, and the retry loop burns MAX_RETRIES and reports "couldn't
+        -- assemble a stack". That is precisely why posting worked when the bag
+        -- already held correctly-sized stacks (the instant Pickup path) and
+        -- failed whenever an actual split was required.
+        job.phase = "cursor"
+        job.wait  = CURSOR_TIMEOUT
+        job.cool  = 0
+    elseif job.phase == "cursor" then
+        -- Wait for the split/pickup to land on the cursor, then hand it to the
+        -- sell slot. Polled per frame, so an instant pickup costs a single tick
+        -- and a slow split costs only as long as it genuinely needs.
+        if CursorHasItem() then
+            ClickAuctionSellItemButton()               -- cursor -> sell slot
+            job.phase = "verify"
+            job.cool  = ASSEMBLE_DELAY
+            return
+        end
+        job.wait = job.wait - (dt or 0)
+        if job.wait <= 0 then
+            job.retries = job.retries + 1
+            if job.retries > MAX_RETRIES then
+                FinishJob("stuck")
+                return
+            end
+            job.phase = "assemble"
+            job.cool  = ASSEMBLE_DELAY
+        end
     elseif job.phase == "verify" then
         local it = sell.GetItem()
         if it and it.itemId == job.itemId and it.count == job.stackSize then

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -61,6 +61,29 @@ local function ChatMsg(text)
     DEFAULT_CHAT_FRAME:AddMessage(text, 0.35, 0.78, 0.98)
 end
 
+-- Set `text` on a FontString, shortened with an ellipsis if it would run wider
+-- than `maxWidth` pixels.
+--
+-- 1.12 has no ellipsis/truncation mode for FontStrings: calling SetWidth() makes
+-- long text WRAP onto a second line rather than clip, which inside a fixed-height
+-- row looks worse than the overflow it was meant to fix. So we deliberately do
+-- NOT constrain the FontString and instead measure with GetStringWidth() and cut
+-- the string ourselves. Binary search keeps it to ~6 SetText calls rather than
+-- one per character.
+function ui.SetTextClipped(fs, text, maxWidth)
+    text = text or ""
+    fs:SetText(text)
+    if not maxWidth or maxWidth <= 0 then return end
+    if fs:GetStringWidth() <= maxWidth then return end
+    local lo, hi = 0, string.len(text)
+    while lo < hi do
+        local mid = math.floor((lo + hi + 1) / 2)
+        fs:SetText(string.sub(text, 1, mid) .. "...")
+        if fs:GetStringWidth() <= maxWidth then lo = mid else hi = mid - 1 end
+    end
+    fs:SetText(string.sub(text, 1, lo) .. "...")
+end
+
 -- A sub-tab button: a dark pill with a centered label, recoloured on select.
 local function MakeSubTab(parent, name)
     local b = CreateFrame("Button", "AegisExchangeSubTab" .. name, parent)
@@ -1183,9 +1206,44 @@ local function BuildResultRow(parent, scroll, store, i, rowH)
         if row.entry then ui.ConfirmBid(row.entry) end
     end)
     row.bidBtn = bidBtn
+    -- Hover tooltip. A Frame gets no OnEnter until its mouse is enabled; the
+    -- Buy/Bid buttons are children so they still take their own clicks.
+    row:EnableMouse(true)
+    row:SetScript("OnEnter", function()
+        ui.ShowListingTooltip(row, row.entry)
+    end)
+    row:SetScript("OnLeave", function() GameTooltip:Hide() end)
     row:Hide()
     store[i] = row
     return row
+end
+
+-- Tooltip for a browse ("list") listing row.
+--
+-- SetAuctionItem indexes into the CURRENTLY loaded page, and our rows are sorted
+-- for display while the page can also be re-queried under us -- so verify the
+-- index still holds the auction we drew before trusting it, exactly as the
+-- Buy/Bid paths do. Falling back to the item link keeps the tooltip useful (item
+-- stats, just not the auction's bid state) when the page has moved on.
+function ui.ShowListingTooltip(owner, r)
+    if not r then return end
+    GameTooltip:SetOwner(owner, "ANCHOR_RIGHT")
+    local shown = false
+    if r.index and GameTooltip.SetAuctionItem and A.buy.Verify(r) then
+        shown = pcall(function() GameTooltip:SetAuctionItem("list", r.index) end)
+    end
+    if not shown then
+        local link = r.index and GetAuctionItemLink
+            and GetAuctionItemLink("list", r.index) or nil
+        if link and GameTooltip.SetHyperlink then
+            shown = pcall(function() GameTooltip:SetHyperlink(link) end)
+        end
+    end
+    if not shown then
+        -- Nothing authoritative left to read; at least name the item.
+        GameTooltip:SetText(r.name or "")
+    end
+    GameTooltip:Show()
 end
 
 -- Fill a result row's content from a listing `r` (shared by Buy and Crafting).
@@ -2688,6 +2746,22 @@ function ui.BuildAuctionsTab()
             if row.entry then ui.ConfirmCancelAuction(row.entry) end
         end)
         row.cancelBtn = cancel
+        -- Hover tooltip, read from the "owner" list rather than "list".
+        row:EnableMouse(true)
+        row:SetScript("OnEnter", function()
+            local r = row.entry
+            if not r then return end
+            GameTooltip:SetOwner(row, "ANCHOR_RIGHT")
+            local shown = false
+            if r.index and GameTooltip.SetAuctionItem then
+                shown = pcall(function()
+                    GameTooltip:SetAuctionItem("owner", r.index)
+                end)
+            end
+            if not shown then GameTooltip:SetText(r.name or "") end
+            GameTooltip:Show()
+        end)
+        row:SetScript("OnLeave", function() GameTooltip:Hide() end)
         row:Hide()
         ui.aucRows[i] = row
         i = i + 1
@@ -3120,6 +3194,15 @@ StaticPopupDialogs["AEGIS_EXCHANGE_CLEARLEDGER"] = {
 local BAG_ROWS,  BAG_ROW_H  = 9, 19
 local LIST_ROWS, LIST_ROW_H = 9, 19
 
+-- Text budget for the "Your Bags" rows. The bag scroll's right edge sits at
+-- panel LEFT + 168 and it starts at LEFT + 12, so a row is ~156 wide; item
+-- labels begin 30px in (past the icon and cache dot) and category headers 4px
+-- in. Long names ("Formula: Enchant Shield - Lesser Protection") used to run
+-- straight past the list into the listings table -- these are what they get
+-- clipped to. See ui.SetTextClipped.
+local BAG_ITEM_TEXT_W = 120
+local BAG_CAT_TEXT_W  = 146
+
 function ui.BuildSellTab()
     local panel = ui.panels["Sell"]
     if not panel or ui.sellBuilt then return end
@@ -3536,6 +3619,26 @@ function ui.BuildSellTab()
                 ui.SyncSellPrices("unit")   -- price the whole stack from it
             end
         end)
+        -- Every row here is a price bucket for the SAME item -- the one in the
+        -- sell slot -- because GroupListings aggregates a single-item scan and
+        -- keeps no per-auction index. So the tooltip comes from the slot rather
+        -- than from an auction index we don't have.
+        row:SetScript("OnEnter", function()
+            if not row.group then return end
+            local it = A.sell.GetItem()
+            if not it then return end
+            GameTooltip:SetOwner(row, "ANCHOR_RIGHT")
+            local shown = false
+            if GameTooltip.SetAuctionSellItem then
+                shown = pcall(function() GameTooltip:SetAuctionSellItem() end)
+            end
+            if not shown and it.link and GameTooltip.SetHyperlink then
+                shown = pcall(function() GameTooltip:SetHyperlink(it.link) end)
+            end
+            if not shown then GameTooltip:SetText(it.name or "") end
+            GameTooltip:Show()
+        end)
+        row:SetScript("OnLeave", function() GameTooltip:Hide() end)
         row:Hide()
         ui.listRows[li] = row
         li = li + 1
@@ -3587,7 +3690,8 @@ function ui.UpdateBagList()
                 row.cacheDot:Hide()
                 row.label:ClearAllPoints()
                 row.label:SetPoint("LEFT", row, "LEFT", 4, 0)
-                row.label:SetText(e.name .. " (" .. e.num .. ")")
+                ui.SetTextClipped(row.label, e.name .. " (" .. e.num .. ")",
+                    BAG_CAT_TEXT_W)
                 row.label:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
             else
                 local it = e.item
@@ -3616,7 +3720,7 @@ function ui.UpdateBagList()
                 row.label:SetPoint("LEFT", row, "LEFT", 30, 0)
                 local txt = it.name
                 if it.count and it.count > 1 then txt = txt .. " x" .. it.count end
-                row.label:SetText(txt)
+                ui.SetTextClipped(row.label, txt, BAG_ITEM_TEXT_W)
                 row.label:SetTextColor(C.text[1], C.text[2], C.text[3])
             end
             row:Show()
@@ -5053,9 +5157,91 @@ function ui.HideBlizzardAH()
     ui.keepSessionOpen = false
 end
 
+-- ---------------------------------------------------------------------------
+-- Right-click a bag item to load it into the Sell tab
+-- ---------------------------------------------------------------------------
+
+-- Only hijack right-click while the Aegis window is up AND Sell is the visible
+-- tab. Everywhere else -- bags open in the world, our other tabs, the stock AH
+-- -- right-click keeps its normal meaning, so eating food or opening a container
+-- still works exactly as it always did.
+function ui.SellRightClickActive()
+    return (ui.frame and ui.frame:IsVisible() and true or false)
+        and ui.selectedSubTab == "Sell"
+        and not A.sell.PostingActive()
+end
+
+-- Load (bag, slot) into the sell slot exactly as clicking its "Your Bags" row
+-- does, so the undercut prefill and the per-item listing scan both fire the same
+-- way. Returns true when we handled the click (caller must then NOT run the
+-- default behaviour).
+function ui.TrySellFromBag(bag, slot)
+    if not bag or not slot then return false end
+    if CursorHasItem and CursorHasItem() then return false end
+    local link = GetContainerItemLink(bag, slot)
+    if not link then return false end
+    -- Soulbound / conjured / otherwise unpostable: fall through to the default
+    -- action rather than silently swallowing the click.
+    if not A.sell.IsAuctionable(bag, slot) then return false end
+    local itemId = util.ItemIdFromLink(link)
+    if not itemId then return false end
+    local texture, count = GetContainerItemInfo(bag, slot)
+    local iname = GetItemInfo(link)
+    if not iname then
+        -- Same cold-item-cache fallback sell.ScanBags uses.
+        local _, _, n = string.find(link, "%[([^%]]+)%]")
+        iname = n
+    end
+    ui.SelectBagEntry({
+        bag = bag, slot = slot, itemId = itemId,
+        name = iname or link, texture = texture, count = count or 1,
+    })
+    return true
+end
+
+-- Save-and-replace (no secure hooks on 1.12) on BOTH right-click paths:
+--
+--   ContainerFrameItemButton_OnClick -- the stock bag buttons.
+--   UseContainerItem                 -- where every bag addon's right-click
+--                                       ultimately lands, so replacement bag
+--                                       UIs (pfUI, Stonkz's Bags, ...) work too.
+--
+-- The first hook returns without chaining when it handles the click, so the
+-- second never double-fires for the stock bags.
+function ui.HookBagRightClick()
+    if ui.bagClickHooked then return end
+    ui.bagClickHooked = true
+
+    if ContainerFrameItemButton_OnClick then
+        ui.orig_ContainerFrameItemButton_OnClick = ContainerFrameItemButton_OnClick
+        ContainerFrameItemButton_OnClick = function(button, ignoreModifiers)
+            if button == "RightButton" and ui.SellRightClickActive() then
+                -- `this` is the clicked item button; its parent carries the bag id.
+                local btn = this
+                local parent = btn and btn.GetParent and btn:GetParent() or nil
+                local bag = parent and parent.GetID and parent:GetID() or nil
+                local slot = btn and btn.GetID and btn:GetID() or nil
+                if ui.TrySellFromBag(bag, slot) then return end
+            end
+            return ui.orig_ContainerFrameItemButton_OnClick(button, ignoreModifiers)
+        end
+    end
+
+    if UseContainerItem then
+        ui.orig_UseContainerItem = UseContainerItem
+        UseContainerItem = function(bag, slot, onSelf)
+            if ui.SellRightClickActive() and ui.TrySellFromBag(bag, slot) then
+                return
+            end
+            return ui.orig_UseContainerItem(bag, slot, onSelf)
+        end
+    end
+end
+
 function ui.OpenWindow()
     ui.BuildWindow()
     ui.HookAuctionFrame()
+    ui.HookBagRightClick()
     ui.showBlizzard = false
     -- Synchronous hide is safe HERE: our AUCTION_HOUSE_SHOW handler runs
     -- after the client's AuctionFrame_Show() has already passed its


### PR DESCRIPTION
All four bugs, each with a regression test verified to fail without its fix. `/reload`-safe — no new `.lua` file.

## 4. "couldn't assemble a stack" — the root cause

Your diagnosis was right: it's the server-side delay. `SplitContainerItem` is a **server round-trip** on 1.12, but the assembler called `ClickAuctionSellItemButton()` **in the same frame** — firing against a still-empty cursor. Slot never fills → verify fails → retries burn → `Posted 0 of N`.

That explains the asymmetry you noticed exactly: when the bag already holds correctly-sized stacks, the code takes the `PickupContainerItem` path, which is client-side and **instant** — so it works. Every path that needed a real split failed.

Added a `cursor` phase that polls until the item actually lands, then hands it over. It exits the frame the cursor fills, so a fast realm pays one tick; a slow one pays only what it needs (2s budget, then retry).

I went with **waiting on the cursor rather than `BAG_UPDATE`** — the split's result *is* the cursor, so that's the direct signal; `BAG_UPDATE` fires for unrelated bag churn too, and using it would need the empty-slot dance your sketch described. This needs no free bag slots at all.

Also found a **latent dead state** while in there: a job whose item was already slotted moved to phase `"post"`, which no branch handles — it would have hung forever instead of posting. Now goes to `"verify"`.

## 1. Right-click to sell

Hooked **both** paths save-and-replace (no secure hooks on 1.12):

- `ContainerFrameItemButton_OnClick` — the stock bags.
- `UseContainerItem` — where replacement bag addons land. Your second screenshot shows **Stonkz's Bags**, which never calls the stock handler, so hooking only the first would have looked broken for you specifically.

Gated on the Aegis window being open **on the Sell tab** *and* the item being postable — so right-click keeps its normal meaning everywhere else, and soulbound items fall through to the default action instead of being silently swallowed.

## 2. Tooltips

Added to the Buy/Crafting result rows, Auctions rows, and Sell listing rows. (The bag list and sell slot already had them.)

Browse rows **re-verify the auction index** before trusting it — `SetAuctionItem` indexes into the currently-loaded page, and our rows are display-sorted while the page can be re-queried underneath, so an unguarded index can describe someone else's auction. Falls back to the item link, then the name. Sell listing rows read the slot item, since `GroupListings` aggregates and keeps no per-auction index.

## 3. Text clipping

**1.12 has no truncation mode** — giving a `FontString` a width makes it *wrap* onto a second line, which inside a 19px row looks worse than the overflow. So `ui.SetTextClipped` measures with `GetStringWidth()` and binary-searches the longest prefix that fits, plus `...` (~6 `SetText` calls, not one per character). No `SetWidth` on the label, deliberately.

## Harness: fixed the sim first

The suite passed with the *old* code — because the mock's `SplitContainerItem` filled the cursor **synchronously**. Same class of gap that hid the whole-stack no-op back in 1.1.0, so I fixed the model before the bug: splits now resolve on a later tick via `Step`. Also stubbed `ContainerFrameItemButton_OnClick` so the right-click hook is driven through its real entry point with `this` set the way the client sets it, not just called directly.

New tests cover the exact reported cases — 30 essences in 3 slots of 10 posted as 6×5, and Gold Bar ×10 posted as 10 singles.

## Verification

`luac5.1 -p` clean on all 10 files; full suite green. Each fix individually reverted to confirm its test bites:

| Reverted | Assertion that fired |
|---|---|
| same-tick click | `exactly 3 auctions posted, got 0` |
| truncation | `an over-wide name is shortened` |
| right-click hook | `right-click through the stock bag button fills the sell slot` |
| result-row tooltip | `buy result rows have a tooltip` |

## One thing worth knowing

While testing I hit a **pre-existing** behaviour: slotting an item starts that item's listing scan, and `SelectBagEntry` declines new selections while a scan is in flight (chat message only). So rapid right-clicks will ignore the second one until the first scan settles — same as clicking bag rows quickly. Not part of these four, left alone, but say the word if you want it queued instead of dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_