### PR TITLE
v1.1.7 + v1.1.8 — Courier integration surface (Phase 0.2), and the split-stack fix

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.6
+## Version: 1.1.7
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.7
+## Version: 1.1.8
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.1.7]
+
+### Added
+- **Integration surface for the companion addon, [Aegis: Courier](https://github.com/Torchlite-bit).**
+  Courier owns the mailbox; this is the seam it pushes through, so it never
+  touches Aegis's saved tables directly and our internals stay free to change:
+  - `AegisExchange.RecordExternalTxn(txn)` — log a sale/purchase Courier
+    matched. Validates the payload and refuses bad ones with a reason rather
+    than corrupting the ledger.
+  - `AegisExchange.MailTxnKey(subject, money, daysLeft)` — the dedup key Aegis
+    has always used for auction mail. Shared deliberately: if you ran Aegis
+    alone for a while, those mails are already in your ledger under these keys,
+    so Courier generating keys through it means installing Courier **doesn't
+    re-count everything you'd already banked**.
+  - `AegisExchange.ClaimMailScanning(name)` / `ReleaseMailScanning()` —
+    Aegis's own mail scanner stands down while Courier owns the inbox. Two
+    scanners on one mailbox means every sale counted twice.
+  - `AegisExchange.INTEGRATION_VERSION` — so a future signature change is a
+    detectable mismatch instead of a silent miscount.
+
+  No effect at all unless a companion addon is installed.
+
 ## [1.1.6]
 
 ### Changed
@@ -373,6 +395,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.1.7]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.6]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.5]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.4]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.1.8]
+
+### Fixed
+- **"couldn't assemble a stack" — actually fixed this time.** Posting anything
+  that needed a genuine split still failed after 1.1.5. The auction slot
+  reliably takes a *whole bag stack*, which is exactly why posting always
+  worked when your bags already held the right sizes and never worked when
+  Aegis had to do the splitting. Waiting for the split to reach the cursor
+  (1.1.5) was necessary but not enough.
+  Aegis now **carves**: it splits the amount off into a spare bag slot, waits
+  for the bags to settle, then posts that new stack down the whole-stack path
+  that always worked. Posting 19 as 2×9, or 9+19 as 3×9, both work now.
+- With **no free bag slot** there's nowhere to carve into, so it says
+  *"no free bag slot to split into"* instead of grinding through retries and
+  blaming the stack assembler.
+- `/aex debug` now traces the posting state machine — which phase gave up, and
+  what the sell slot actually held when it did. "Couldn't assemble a stack"
+  never told anyone anything; if it happens again, that trace will.
+
+### Changed
+- **No more tooltips on the Sell tab's listings rows.** Every row there is the
+  same item that's already in the sell slot, so the tooltip just repeated the
+  header — and anchored that far right it hung off the side of the window.
+  Tooltips stay where they tell you something you can't already see: the
+  **Your Bags** list and the sell slot itself.
+- The listings table's **Unit price** column is inset 4px instead of sitting
+  flush against the row border, where it read as clipped.
+
 ## [1.1.7]
 
 ### Added
@@ -395,6 +423,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.1.8]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.7]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.6]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.5]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.1.7)
+# Aegis: Exchange (v1.1.8)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -239,7 +239,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.7`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.8`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.1.6)
+# Aegis: Exchange (v1.1.7)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -239,7 +239,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.6`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.7`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,25 +46,55 @@ better attribution available, and it self-corrects within `KEEP_DAYS` as fresh
 scans age the old dailies out. Discarding history on upgrade would have been
 worse for everyone.
 
-### 0.2 Aegis: Courier integration surface
-**Decided** (contract; implementation is this phase's task). Expose the
-seam Courier will build against, so that repo has something stable from day
-one instead of chasing a moving target:
+### 0.2 Aegis: Courier integration surface — ✅ **DONE** (v1.1.7)
 
-- `AegisExchange.RecordExternalTxn(...)` (naming TBD at implementation time)
-  — the one function Courier calls to push a matched mail transaction into
-  Aegis's ledger. Courier never touches `AegisExchangeDB`'s internal shape
-  directly; this function is the whole contract, so Aegis's internals can
-  keep changing freely as long as the signature holds.
-- `AegisExchange.INTEGRATION_VERSION` (or similar) — a small version number
-  Courier checks so a future signature change is a detectable mismatch, not
-  a silent miscount.
-- Aegis's existing built-in mail scanner (`ui/frame.lua` `ScanMailSales` /
-  `AuctionSoldItem`, shipped 0.17.0) detects Courier at `ADDON_LOADED` and
-  **stands down** — skips installing its own mail hook — so a user running
-  both addons never gets double-hooked mailbox handlers or double-counted
-  sales. Courier becomes sole owner of mail scanning the moment it's
-  installed; Aegis's own scanner is only active when Courier isn't present.
+Shipped in `core/db.lua` under a single "Companion-addon integration surface"
+block — that block is the whole contract. **This is what Courier calls:**
+
+```lua
+-- Guard every use; Aegis may not be installed.
+if AegisExchange and AegisExchange.INTEGRATION_VERSION then
+
+    -- 1. Take ownership of the mailbox. Aegis's own scanner stands down.
+    --    Call from Courier's ADDON_LOADED.
+    AegisExchange.ClaimMailScanning("Aegis: Courier")
+
+    -- 2. Build the dedup key for an auction mail THROUGH THIS HELPER.
+    local key = AegisExchange.MailTxnKey(subject, money, daysLeft)
+
+    -- 3. Push the matched transaction.
+    local ok, why = AegisExchange.RecordExternalTxn({
+        kind   = "sale",        -- or "buy"
+        item   = "Silk Cloth",
+        amount = netProceeds,   -- copper, AFTER the 5% cut (what actually
+                                -- arrived in the mail)
+        itemId = 4306,          -- optional
+        key    = key,           -- optional; repeats are ignored
+    })
+end
+```
+
+`RecordExternalTxn` returns `true`, or `false` plus a short reason
+(`"duplicate"`, `"kind must be 'sale' or 'buy'"`, …) so Courier can surface
+failures rather than miscounting silently. `INTEGRATION_VERSION` is currently
+**1**; it bumps whenever a signature or field meaning changes.
+
+**Why `MailTxnKey` is exposed rather than left internal.** A user who ran Aegis
+alone already has auction mails in the ledger under *Aegis's* keys. If Courier
+invented its own key scheme it would re-report those mails and double-count
+every one of them on the day Courier is installed. Generating keys through the
+shared helper makes the handover seamless. This matters more than it looks — it
+is the single most likely way the integration could corrupt someone's history.
+
+**Mail ownership** is an explicit handshake (`ClaimMailScanning` /
+`ReleaseMailScanning`) rather than Aegis sniffing for a global, because explicit
+survives Courier being renamed. There *is* a global-name fallback for a Courier
+that loads without claiming, but it is a safety net, not the contract.
+
+> ⚠️ **Open, for the Courier session to close:** that fallback currently guesses
+> at `AegisCourier` / `Aegis_Courier`. Once Courier settles its real addon
+> global, trim `COURIER_GLOBALS` in `core/db.lua` to the true name. Harmless
+> either way as long as Courier calls `ClaimMailScanning`.
 
 Full design (data-flow direction, standalone requirement) below in **Phase 1**.
 

--- a/core/db.lua
+++ b/core/db.lua
@@ -430,6 +430,113 @@ function db.MarkSeen(key)
     db.account.ledgerSeen[key] = true
 end
 
+-- ---------------------------------------------------------------------------
+-- Companion-addon integration surface (Aegis: Courier)
+-- ---------------------------------------------------------------------------
+--
+-- Everything a companion addon needs lives in this block. It is THE contract:
+-- Courier calls these and never touches AegisExchangeDB's internal shape, so
+-- our tables can keep changing as long as these signatures hold.
+--
+-- Data flows Courier -> Aegis, one direction only. We never read Courier's
+-- SavedVariables.
+
+-- Bump when a signature or payload field below changes meaning. Courier reads
+-- this and can refuse to integrate (rather than silently miscount) on a
+-- mismatch.
+--   1 -- RecordExternalTxn(txn), MailTxnKey(), ClaimMailScanning()
+A.INTEGRATION_VERSION = 1
+
+-- Dedup key for an auction-house mail, built the way Aegis's own mail scanner
+-- has always built it.
+--
+-- Exposed deliberately: a user who ran Aegis alone for a while already has
+-- those mails in the ledger under THESE keys. If Courier invented its own key
+-- scheme it would re-report mail Aegis had already logged and double-count it
+-- on the day Courier is installed. Generating the key through here makes the
+-- handover seamless.
+--
+-- `daysLeft` is the mail's remaining lifetime from GetInboxHeaderInfo. Arrival
+-- epoch is stable as daysLeft falls and `now` rises; bucketing to the hour
+-- gives a key that survives relogins.
+function A.MailTxnKey(subject, money, daysLeft)
+    local arrival = math.floor((time() - (daysLeft or 0) * 86400) / 3600)
+    return tostring(subject) .. "|" .. tostring(money) .. "|" .. arrival
+end
+
+-- Record a transaction observed by a companion addon.
+--
+-- txn = {
+--   kind   = "sale" | "buy",   -- required; money in / money out
+--   item   = "Silk Cloth",     -- required; display name
+--   amount = 12345,            -- required; copper, > 0. For a sale this should
+--                              -- be NET proceeds (after the 5% cut), because
+--                              -- that is what actually arrived in the mail.
+--   itemId = 4306,             -- optional
+--   key    = "...",            -- optional dedup key; use A.MailTxnKey for AH
+--                              -- mail. Repeats with the same key are ignored,
+--                              -- so re-scanning a mailbox is safe.
+-- }
+--
+-- Returns true on success, or false plus a short reason. Courier can surface
+-- the reason rather than failing silently.
+function A.RecordExternalTxn(txn)
+    if type(txn) ~= "table" then return false, "payload must be a table" end
+    if txn.kind ~= "sale" and txn.kind ~= "buy" then
+        return false, "kind must be 'sale' or 'buy'"
+    end
+    if type(txn.amount) ~= "number" or txn.amount <= 0 then
+        return false, "amount must be a positive number of copper"
+    end
+    if not db.account then return false, "Aegis DB not loaded yet" end
+    if txn.key then
+        if db.WasSeen(txn.key) then return false, "duplicate" end
+        db.MarkSeen(txn.key)
+    end
+    db.RecordTxn(txn.kind, txn.item or "?", txn.amount, txn.itemId)
+    return true
+end
+
+-- Mail-scanning ownership.
+--
+-- Aegis has scanned the mailbox for "Auction successful" mail since 0.17.0. If
+-- Courier is installed it owns that job -- it reads mail far more thoroughly --
+-- and Aegis must stand down, or a user running both gets two hooks racing over
+-- the same inbox and sales counted twice.
+--
+-- Preferred handshake: Courier calls A.ClaimMailScanning("Aegis: Courier") from
+-- its own ADDON_LOADED. Explicit beats sniffing, and it works whatever the
+-- addon ends up being called.
+function A.ClaimMailScanning(who)
+    A.mailScanOwner = who or "external"
+    return true
+end
+
+function A.ReleaseMailScanning()
+    A.mailScanOwner = nil
+    return true
+end
+
+-- Globals we also accept as proof a Courier is present, for the case where it
+-- loads without calling ClaimMailScanning.
+--
+-- PLACEHOLDER: Aegis: Courier has not named its addon global yet. Confirm the
+-- real name once that repo settles it and trim this list -- the explicit claim
+-- above is the contract, this is only a safety net.
+local COURIER_GLOBALS = { "AegisCourier", "Aegis_Courier" }
+
+-- Is something else responsible for reading the mailbox?
+function A.MailScanningExternal()
+    if A.mailScanOwner then return true end
+    local i = 1
+    while i <= table.getn(COURIER_GLOBALS) do
+        local g = getglobal(COURIER_GLOBALS[i])
+        if type(g) == "table" then return true end
+        i = i + 1
+    end
+    return false
+end
+
 -- Income / spend / count over transactions at or after `sinceEpoch` (nil = all).
 function db.LedgerTotals(sinceEpoch)
     local income, spend, n = 0, 0, 0

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,10 +22,15 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.6"
+A.version = "1.1.7"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)
+
+-- Companion-addon integration (Aegis: Courier) is defined in core/db.lua, next
+-- to the ledger it writes into: A.INTEGRATION_VERSION, A.RecordExternalTxn,
+-- A.MailTxnKey, A.ClaimMailScanning / A.ReleaseMailScanning and
+-- A.MailScanningExternal. That block is the whole public contract.
 
 -- ---------------------------------------------------------------------------
 -- Event dispatch

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.7"
+A.version = "1.1.8"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/sell.lua
+++ b/core/sell.lua
@@ -792,6 +792,16 @@ function sell.DepositFor(itemId, stackSize, minutes, maxStack)
     return base
 end
 
+-- Trace the posting state machine. Shares the /aex debug flag with the scanner,
+-- because "it says couldn't assemble a stack" is impossible to diagnose from
+-- the outside -- this prints which phase gave up and what the slot actually
+-- held.
+function sell.Debug(msg)
+    if A.debugScan and DEFAULT_CHAT_FRAME then
+        DEFAULT_CHAT_FRAME:AddMessage("|cff5fc8f8Aegis post:|r " .. msg)
+    end
+end
+
 -- First postable bag slot holding at least `minCount` of the item, or nil.
 local function FindStack(itemId, minCount)
     local bag = 0
@@ -808,6 +818,46 @@ local function FindStack(itemId, minCount)
             slot = slot + 1
         end
         bag = bag + 1
+    end
+    return nil
+end
+
+-- A bag slot holding EXACTLY `count` of the item. This is the stack the
+-- assembler actually wants: the auction slot takes a whole bag stack reliably,
+-- which is why posting always worked when the bag already held the right sizes.
+local function FindExactStack(itemId, count)
+    local bag = 0
+    while bag <= 4 do
+        local slots = GetContainerNumSlots(bag) or 0
+        local slot = 1
+        while slot <= slots do
+            local link = GetContainerItemLink(bag, slot)
+            if link and util.ItemIdFromLink(link) == itemId
+                and sell.IsAuctionable(bag, slot) then
+                local _, c = GetContainerItemInfo(bag, slot)
+                if (c or 0) == count then return bag, slot end
+            end
+            slot = slot + 1
+        end
+        bag = bag + 1
+    end
+    return nil
+end
+
+-- First empty bag slot, for carving a split stack into. Backpack (0) last so we
+-- prefer real bags and leave the backpack free for loot.
+local function FindEmptySlot()
+    local order = { 1, 2, 3, 4, 0 }
+    local i = 1
+    while i <= table.getn(order) do
+        local bag = order[i]
+        local slots = GetContainerNumSlots(bag) or 0
+        local slot = 1
+        while slot <= slots do
+            if not GetContainerItemLink(bag, slot) then return bag, slot end
+            slot = slot + 1
+        end
+        i = i + 1
     end
     return nil
 end
@@ -898,6 +948,19 @@ function sell.PostTick(dt)
         return
     end
 
+    -- ASSEMBLY STRATEGY. The auction slot reliably accepts a WHOLE bag stack --
+    -- that is why posting always worked when the bags already held the right
+    -- sizes, and why every attempt that needed a genuine split failed, both
+    -- before 1.1.5 and after it. Waiting for the split to reach the cursor
+    -- (1.1.5) was necessary but not sufficient.
+    --
+    -- So we never hand the auction slot a floating split. When the bag has more
+    -- than we want, we CARVE: split the exact amount off, drop it into an empty
+    -- bag slot, wait for the bags to settle, and then post that new stack down
+    -- the same whole-stack path that has always worked. Phases:
+    --
+    --   assemble -> (exact stack exists?) -> place -> verify -> post
+    --            -> (need to carve)       -> carve -> settle -> assemble
     if job.phase == "assemble" then
         local it = sell.GetItem()
         if it and it.itemId == job.itemId and it.count == job.stackSize then
@@ -909,39 +972,90 @@ function sell.PostTick(dt)
             return
         end
         if CursorHasItem() then ClearCursor() end
-        local bag, slot = FindStack(job.itemId, job.stackSize)
-        if not bag then
-            FinishJob("out")             -- can't build another stack
+        -- An occupied slot makes ClickAuctionSellItemButton SWAP rather than
+        -- place, so empty it before we put anything in.
+        if it then sell.ClearSlot() end
+
+        -- Preferred: a bag stack that is already exactly the size we want.
+        local bag, slot = FindExactStack(job.itemId, job.stackSize)
+        if bag then
+            sell.Debug("placing exact stack from bag " .. bag .. " slot " .. slot)
+            PickupContainerItem(bag, slot)
+            job.phase = "place"
+            job.wait  = CURSOR_TIMEOUT
+            job.cool  = 0
             return
         end
-        -- CRITICAL: SplitContainerItem is for taking PART of a stack. Asking it
-        -- to split the WHOLE stack (count == what's in the slot) is a no-op on
-        -- 1.12, so the cursor stays empty, ClickAuctionSellItemButton does
-        -- nothing, verify never sees the item, and the job died with
-        -- "couldn't assemble a stack" -- which is exactly the
-        -- "Posted 0 of 1" failure, since a single full stack always hits this.
-        -- Pick the whole stack up instead when the counts match.
-        local _, slotCount = GetContainerItemInfo(bag, slot)
-        if (slotCount or 0) <= job.stackSize then
-            PickupContainerItem(bag, slot)             -- whole stack -> cursor
-        else
-            SplitContainerItem(bag, slot, job.stackSize)   -- part of it
+
+        -- Otherwise carve one off a larger stack.
+        local src, srcSlot = FindStack(job.itemId, job.stackSize + 1)
+        if not src then
+            -- Nothing big enough either. Items can be briefly absent -- a stack
+            -- we just posted leaves the bags via the server -- so retry a few
+            -- times before declaring we've run out.
+            job.finds = (job.finds or 0) + 1
+            if job.finds > MAX_RETRIES then
+                sell.Debug("no stack of " .. job.stackSize .. " left; finishing")
+                FinishJob("out")
+                return
+            end
+            job.cool = ASSEMBLE_DELAY
+            return
         end
-        -- Do NOT click the sell button in this same tick. PickupContainerItem
-        -- puts the stack on the cursor immediately (client-side), but
-        -- SplitContainerItem needs a SERVER ROUND-TRIP on 1.12 -- so clicking
-        -- now fires against an empty cursor, the sell slot stays empty, verify
-        -- fails, and the retry loop burns MAX_RETRIES and reports "couldn't
-        -- assemble a stack". That is precisely why posting worked when the bag
-        -- already held correctly-sized stacks (the instant Pickup path) and
-        -- failed whenever an actual split was required.
-        job.phase = "cursor"
+        job.finds = 0
+        local eb, es = FindEmptySlot()
+        if not eb then
+            sell.Debug("no free bag slot to carve into")
+            FinishJob("nospace")
+            return
+        end
+        sell.Debug("carving " .. job.stackSize .. " off bag " .. src
+            .. " slot " .. srcSlot .. " into bag " .. eb .. " slot " .. es)
+        job.carveBag, job.carveSlot = eb, es
+        SplitContainerItem(src, srcSlot, job.stackSize)
+        job.phase = "carve"
         job.wait  = CURSOR_TIMEOUT
         job.cool  = 0
-    elseif job.phase == "cursor" then
-        -- Wait for the split/pickup to land on the cursor, then hand it to the
-        -- sell slot. Polled per frame, so an instant pickup costs a single tick
-        -- and a slow split costs only as long as it genuinely needs.
+
+    elseif job.phase == "carve" then
+        -- SplitContainerItem is a server round-trip; wait for the cursor, then
+        -- drop the carved stack into the empty slot we reserved.
+        if CursorHasItem() then
+            PickupContainerItem(job.carveBag, job.carveSlot)
+            job.phase = "settle"
+            job.wait  = CURSOR_TIMEOUT
+            job.cool  = 0
+            return
+        end
+        job.wait = job.wait - (dt or 0)
+        if job.wait <= 0 then
+            sell.Debug("split never reached the cursor")
+            job.retries = job.retries + 1
+            if job.retries > MAX_RETRIES then FinishJob("stuck"); return end
+            job.phase = "assemble"
+            job.cool  = ASSEMBLE_DELAY
+        end
+
+    elseif job.phase == "settle" then
+        -- Wait for the bags to actually show the new stack, then let assemble
+        -- pick it up down the proven whole-stack path.
+        if FindExactStack(job.itemId, job.stackSize) then
+            if CursorHasItem() then ClearCursor() end
+            job.phase = "assemble"
+            job.cool  = 0
+            return
+        end
+        job.wait = job.wait - (dt or 0)
+        if job.wait <= 0 then
+            sell.Debug("carved stack never appeared in the bags")
+            job.retries = job.retries + 1
+            if job.retries > MAX_RETRIES then FinishJob("stuck"); return end
+            job.phase = "assemble"
+            job.cool  = ASSEMBLE_DELAY
+        end
+
+    elseif job.phase == "place" then
+        -- Wait for the pickup to land on the cursor, then hand it to the slot.
         if CursorHasItem() then
             ClickAuctionSellItemButton()               -- cursor -> sell slot
             job.phase = "verify"
@@ -950,14 +1064,13 @@ function sell.PostTick(dt)
         end
         job.wait = job.wait - (dt or 0)
         if job.wait <= 0 then
+            sell.Debug("pickup never reached the cursor")
             job.retries = job.retries + 1
-            if job.retries > MAX_RETRIES then
-                FinishJob("stuck")
-                return
-            end
+            if job.retries > MAX_RETRIES then FinishJob("stuck"); return end
             job.phase = "assemble"
             job.cool  = ASSEMBLE_DELAY
         end
+
     elseif job.phase == "verify" then
         local it = sell.GetItem()
         if it and it.itemId == job.itemId and it.count == job.stackSize then
@@ -974,7 +1087,15 @@ function sell.PostTick(dt)
                 job.callbacks.onProgress(job.posted, job.requested)
             end
         else
-            -- Assembly didn't land yet; retry a few times, then give up.
+            -- Assembly didn't land yet; retry a few times, then give up. The
+            -- trace names what the slot actually held, which is the one thing
+            -- "couldn't assemble a stack" never told anybody.
+            local got = "empty"
+            if it then
+                got = tostring(it.itemId) .. " x" .. tostring(it.count)
+            end
+            sell.Debug("verify: slot has " .. got .. ", wanted "
+                .. tostring(job.itemId) .. " x" .. tostring(job.stackSize))
             job.retries = job.retries + 1
             if job.retries > MAX_RETRIES then
                 FinishJob("stuck")

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -2986,6 +2986,11 @@ end
 -- Scan the open mailbox for AH sale mails and log each one once (deduped by an
 -- approximate arrival time so the same mail isn't re-counted across sessions).
 function ui.ScanMailSales()
+    -- Stand down when a companion addon (Aegis: Courier) owns the mailbox.
+    -- Two scanners on one inbox means two hooks racing and sales counted
+    -- twice; Courier reads mail far more thoroughly, so it wins. See the
+    -- integration block in core/db.lua.
+    if A.MailScanningExternal and A.MailScanningExternal() then return end
     if not GetInboxNumItems then return end
     local n = GetInboxNumItems() or 0
     local i = 1
@@ -2993,10 +2998,10 @@ function ui.ScanMailSales()
         local _, _, sender, subject, money, _, daysLeft = GetInboxHeaderInfo(i)
         local item = AuctionSoldItem(subject)
         if item and money and money > 0 then
-            -- Arrival epoch is stable as daysLeft falls and `now` rises; bucket
-            -- to the hour for a key that survives relogins.
-            local arrival = math.floor((time() - (daysLeft or 0) * 86400) / 3600)
-            local key = subject .. "|" .. money .. "|" .. arrival
+            -- Key built through the shared helper, which Courier also calls --
+            -- that is what stops a mail Aegis already logged from being
+            -- re-counted when Courier takes over.
+            local key = A.MailTxnKey(subject, money, daysLeft)
             if not A.db.WasSeen(key) then
                 A.db.MarkSeen(key)
                 A.db.RecordTxn("sale", item, money)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -3581,7 +3581,7 @@ function ui.BuildSellTab()
         ui.sellHeaders[key] = b
         return b
     end
-    mkCol(colX.unit,  "Unit price",  "unit",  88)
+    mkCol(colX.unit + 4, "Unit price", "unit", 84)   -- +4: matches the row inset
     mkCol(colX.avail, "Available",   "avail", 156)
     mkCol(colX.stack, "Stack price", "stack", 136)
     mkCol(colX.pct,   "% mkt",       "pct",   50)
@@ -3618,7 +3618,10 @@ function ui.BuildSellTab()
             fs:SetJustifyH(just or "LEFT")
             return fs
         end
-        row.unit  = mkCell(0, 86)
+        -- 4px in, not flush with the row's left edge: at 0 the price sat
+        -- against the row border (and against the highlight box under the pfUI
+        -- skin), which read as clipped. The header below is inset to match.
+        row.unit  = mkCell(4, 84)
         row.avail = mkCell(92, 158)
         row.stack = mkCell(252, 130)
         row.pct   = mkCell(392, 48)
@@ -3630,26 +3633,12 @@ function ui.BuildSellTab()
                 ui.SyncSellPrices("unit")   -- price the whole stack from it
             end
         end)
-        -- Every row here is a price bucket for the SAME item -- the one in the
-        -- sell slot -- because GroupListings aggregates a single-item scan and
-        -- keeps no per-auction index. So the tooltip comes from the slot rather
-        -- than from an auction index we don't have.
-        row:SetScript("OnEnter", function()
-            if not row.group then return end
-            local it = A.sell.GetItem()
-            if not it then return end
-            GameTooltip:SetOwner(row, "ANCHOR_RIGHT")
-            local shown = false
-            if GameTooltip.SetAuctionSellItem then
-                shown = pcall(function() GameTooltip:SetAuctionSellItem() end)
-            end
-            if not shown and it.link and GameTooltip.SetHyperlink then
-                shown = pcall(function() GameTooltip:SetHyperlink(it.link) end)
-            end
-            if not shown then GameTooltip:SetText(it.name or "") end
-            GameTooltip:Show()
-        end)
-        row:SetScript("OnLeave", function() GameTooltip:Hide() end)
+        -- DELIBERATELY NO TOOLTIP on these rows. Every row here is a price
+        -- bucket for the SAME item -- the one already in the sell slot -- so a
+        -- tooltip repeats what the header shows, and anchored off a row this
+        -- far right it hangs outside the window. The Sell tab shows item
+        -- tooltips only where they tell you something you can't already see:
+        -- the "Your Bags" list and the sell slot itself.
         row:Hide()
         ui.listRows[li] = row
         li = li + 1
@@ -4651,8 +4640,11 @@ function ui.DoPost()
                     msg = msg .. " (hit the auction cap)"
                 elseif reason == "cancelled" then
                     msg = "Posting cancelled after " .. done .. "."
+                elseif reason == "nospace" then
+                    msg = msg .. " (no free bag slot to split into)"
                 elseif reason == "stuck" then
-                    msg = msg .. " (couldn't assemble a stack)"
+                    msg = msg .. " (couldn't assemble a stack \226\128\148"
+                        .. " /aex debug shows why)"
                 end
                 ui.sellStatus:SetText(msg)
                 ChatMsg("Aegis: " .. msg)


### PR DESCRIPTION
Two commits. You asked to hold off merging until the split bug was addressed, so it's in here rather than in a separate PR.

| | |
|---|---|
| **v1.1.7** | Phase 0.2 — the integration surface Aegis: Courier builds against |
| **v1.1.8** | The split-stack bug, plus the two Sell tab fixes you reported |

---

# v1.1.8 — "couldn't assemble a stack", actually fixed

I got this wrong twice, so here's the reasoning rather than another assertion that it's fixed.

**The pattern in your reports:** 19 posted as 2×9, and 9+19 posted as 3×9. Both need a **real split**, both failed. Whole-stack posting has never failed — including when you pre-split by hand.

**What that means:** the auction slot reliably accepts a *whole bag stack*. Waiting for the split to reach the cursor (1.1.5) was necessary but not sufficient — the slot then declines the floating stack the cursor is holding.

**The fix:** never hand it a floating split. Aegis now **carves** — splits the amount off into a spare bag slot, waits for the bags to settle, then posts that new stack down the whole-stack path that always worked:

```
assemble → place → verify → post          (a stack that's already the right size)
assemble → carve → settle → assemble      (one that has to be cut)
```

This is the approach you originally suggested. I tried the cursor-only fix first; the evidence now supports yours.

**Also:**
- No free bag slot → *"no free bag slot to split into"*, instead of grinding through retries and blaming the assembler.
- `FindStack` failures retry rather than instantly reporting "ran out" — a just-posted stack leaves the bags via the server.
- **`/aex debug` now traces the posting machine** — which phase gave up, and what the sell slot actually held when verify failed. "Couldn't assemble a stack" told nobody anything, which is precisely why this took three attempts. If it recurs, that trace will say why.

## Sell tab

- **No tooltips on the listings rows.** Every row is the same item already in the sell slot, so it repeated the header — and anchored that far right it hung off the side of the window (visible in your screenshot). Tooltips stay on the **Your Bags** list and the sell slot, where they tell you something you can't already see.
- **Unit price column** inset 4px instead of flush against the row border, where it read as clipped.

## The harness was the real problem

Three fidelity gaps, and they're why this survived two rounds of "verified":

- **`GetContainerNumSlots` returned the highest occupied key** — so every bag was always exactly *full* and an empty slot could not exist. The sim literally could not represent "carve into a spare slot."
- **`PickupContainerItem` only ever picked *up*** — dropping the cursor into an empty slot did nothing, so a carve had nowhere to land.
- **`ClickAuctionSellItemButton` now models the slot refusing a floating split.** That's a *hypothesis* about the real client, not something provable from here — so it's a flag, and **the suite runs both ways**. The fix passes under the strict model and the lenient one, whichever turns out to be true in game.

**Verified:** suite green under both models; the pre-carve approach fails under the strict model with `exactly 3 auctions posted, got 0`. Both of your exact cases are regression tests now.

---

# v1.1.7 — Phase 0.2 (unchanged)

The seam Courier builds against. **No behaviour change unless a companion addon is installed.**

```lua
if AegisExchange and AegisExchange.INTEGRATION_VERSION then
    AegisExchange.ClaimMailScanning("Aegis: Courier")   -- Aegis stands down

    local key = AegisExchange.MailTxnKey(subject, money, daysLeft)
    local ok, why = AegisExchange.RecordExternalTxn({
        kind = "sale", item = "Silk Cloth", amount = netProceeds,
        itemId = 4306, key = key,
    })
end
```

**`MailTxnKey` is exposed deliberately.** If you've run Aegis alone, those mails are already in your ledger under Aegis's keys — a separate key scheme in Courier would re-report every one of them and double your recorded income the day you install it. This is the likeliest way the integration could corrupt real gold history, so it's the bit most worth a second opinion.

**Mail ownership is an explicit handshake**, not global-sniffing — that survives Courier being renamed.

> ⚠️ **Open for the Courier session:** the fallback currently *guesses* at `AegisCourier` / `Aegis_Courier`. Trim `COURIER_GLOBALS` in `core/db.lua` once Courier names its global. Harmless as long as Courier calls `ClaimMailScanning` — flagged in ROADMAP.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L