### PR TITLE
v1.1.9 — Sell tab sliders + g/s/c prices, and richer tooltips with per-line options

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.8
+## Version: 1.1.9
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ printed in the window title bar — quote it in bug reports.
 ## [1.1.9]
 
 ### Added
+- **Tooltips now price more surfaces** — loot windows, quest rewards, the quest
+  log, and profession reagents, on top of bags, inventory, the AH, merchants and
+  the mailbox. Hover a reagent in a profession window and see what it's worth
+  without leaving it.
+- **Aegis tab controls which lines appear**: Market value, Minimum buyout and
+  Vendor price each toggle independently under the master tooltip switch, which
+  greys them when it's off.
+- **"Stack totals only while Shift is held"** — off by default, so nothing
+  changes unless you want it. On, a tooltip shows the unit price and only adds
+  `(x20 = 24g)` while Shift is down, which keeps things short in a bank full of
+  stacks.
 - **Stack size and stack count are sliders now**, and they interlock — drag the
   size and the count's ceiling follows, because bigger stacks means fewer of
   them. The size slider stops at the item's own max stack (or what you're

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.1.9]
+
+### Added
+- **Stack size and stack count are sliders now**, and they interlock — drag the
+  size and the count's ceiling follows, because bigger stacks means fewer of
+  them. The size slider stops at the item's own max stack (or what you're
+  actually carrying, whichever is smaller), so you can't ask for a stack the
+  game won't allow. The line beside them reads `= 27 of 28`, so you can see
+  what you're about to list against what you hold.
+- **Prices are entered in gold / silver / copper**, one box each, like the
+  stock auction house — instead of typing `1g 88s`.
+- **Bid per item** is now its own field, separate from **Buy per item**. Leave
+  it blank and the start bid follows the buyout, exactly as before.
+
+### Changed
+- The editable **stack price** box is gone. With a stack-size slider it was a
+  second way to say the same thing, and the two boxes rounding into each other
+  made your price drift as you dragged. The stack total is shown on the right
+  instead (`3 x 16s 92c = 50s 76c`).
+
+### Fixed
+- The stack assembler now waits when a bag slot is **locked** (mid-move on the
+  server) instead of splitting into it and burning a retry on a cursor that was
+  never going to fill.
+
 ## [1.1.8]
 
 ### Fixed
@@ -423,6 +448,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.1.9]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.8]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.7]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.6]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.1.8)
+# Aegis: Exchange (v1.1.9)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -239,7 +239,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.8`) — quote it.
+1. Check the **version** in the window's title bar (`v1.1.9`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ undercut rule (% or flat), auto-fill price, tooltip lines, profit line, and the
 pfUI skin — all in one place.
 
 ### 💬 Tooltips everywhere
-Every item tooltip — bags, inventory, the AH, even the mailbox — gains market
-value, minimum buyout, and vendor price, with stack totals.
+Bags, inventory, the auction house, merchants, the mailbox, **loot windows,
+quest rewards and profession reagents** — all gain market value, minimum buyout
+and vendor price, with stack totals. Pick which of those three lines you want on
+the Aegis tab, and optionally show stack totals only while **Shift** is held.
 
 ---
 

--- a/core/db.lua
+++ b/core/db.lua
@@ -107,7 +107,17 @@ local SETTING_DEFAULTS = {
     undercutPct    = 5,         -- percent below the reference (pct mode)
     undercutAmount = 1,         -- copper below the reference (flat mode)
     sellDefault    = "undercut", -- slot prefill: "undercut"|"market"|"none"
-    tooltip        = true,      -- show Aegis price lines on item tooltips
+    tooltip        = true,      -- master switch for Aegis price lines
+    -- Which lines the tooltip shows, all on by default so the behaviour is
+    -- unchanged for anyone who never opens these. Only consulted when the
+    -- master `tooltip` switch is on.
+    tipMarket      = true,      -- "Aegis Market" (time-weighted median)
+    tipMinBuyout   = true,      -- "Aegis Min Buyout" (most recent daily low)
+    tipVendor      = true,      -- "Aegis Vendor Price"
+    -- Stack totals -- "(x20 = 24g)" after a unit price. false = always show,
+    -- true = only while Shift is held, which is how aux does it and keeps the
+    -- tooltip short on a bank full of stacks.
+    tipStackShift  = false,
     profLine       = true,      -- show the profit line on profession windows
     pfSkin         = true,      -- match pfUI's look when pfUI is installed
     -- Query pacing between scan pages:

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.8"
+A.version = "1.1.9"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/sell.lua
+++ b/core/sell.lua
@@ -844,6 +844,15 @@ local function FindExactStack(itemId, count)
     return nil
 end
 
+-- Is this bag slot mid-move? GetContainerItemInfo's 3rd return is `locked`,
+-- which the client sets while the server is still processing a move. Acting on
+-- a locked slot is how a split silently does nothing -- so we wait instead of
+-- burning a retry. (Technique noted from how aux paces its stack moves.)
+local function SlotLocked(bag, slot)
+    local _, _, locked = GetContainerItemInfo(bag, slot)
+    return locked and true or false
+end
+
 -- First empty bag slot, for carving a split stack into. Backpack (0) last so we
 -- prefer real bags and leave the backpack free for loot.
 local function FindEmptySlot()
@@ -1007,6 +1016,13 @@ function sell.PostTick(dt)
         if not eb then
             sell.Debug("no free bag slot to carve into")
             FinishJob("nospace")
+            return
+        end
+        -- Never split out of a slot the server is still moving: the call is
+        -- silently dropped and we'd waste a retry waiting for a cursor that
+        -- was never going to fill.
+        if SlotLocked(src, srcSlot) or SlotLocked(eb, es) then
+            job.cool = ASSEMBLE_DELAY
             return
         end
         sell.Debug("carving " .. job.stackSize .. " off bag " .. src

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -666,13 +666,64 @@ function ui.BuildAegisSettings(panel, anchorAbove)
     end
     tipChk:SetScript("OnClick", function()
         A.db.SetSetting("tooltip", tipChk:GetChecked() and true or false)
+        ui.RefreshSettings()   -- grey the per-line options with the master
     end)
     ui.setTooltip = tipChk
+
+    -- Per-line tooltip options, indented under the master toggle because they
+    -- only mean anything while it's on. Tooltips now reach loot, quest rewards
+    -- and profession reagents as well as bags and the AH, so being able to trim
+    -- the lines back matters more than it did.
+    local tipSubs = {
+        { key = "tipMarket",     text = "Market value" },
+        { key = "tipMinBuyout",  text = "Minimum buyout" },
+        { key = "tipVendor",     text = "Vendor price" },
+    }
+    ui.setTipSubs = {}
+    local prevSub = nil
+    local si = 1
+    while si <= table.getn(tipSubs) do
+        local spec = tipSubs[si]
+        local c = CreateFrame("CheckButton", "AegisExchangeSet" .. spec.key,
+            panel, "UICheckButtonTemplate")
+        c:SetWidth(20); c:SetHeight(20)
+        if prevSub then
+            c:SetPoint("TOPLEFT", prevSub, "BOTTOMLEFT", 0, -1)
+        else
+            c:SetPoint("TOPLEFT", tipChk, "BOTTOMLEFT", 18, -2)
+        end
+        local t = getglobal(c:GetName() .. "Text")
+        if t then
+            t:SetText(spec.text)
+            t:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+        end
+        c.settingKey = spec.key
+        c:SetScript("OnClick", function()
+            A.db.SetSetting(c.settingKey, c:GetChecked() and true or false)
+        end)
+        ui.setTipSubs[si] = c
+        prevSub = c
+        si = si + 1
+    end
+
+    local stackChk = CreateFrame("CheckButton", "AegisExchangeSetTipStackShift",
+        panel, "UICheckButtonTemplate")
+    stackChk:SetWidth(20); stackChk:SetHeight(20)
+    stackChk:SetPoint("TOPLEFT", prevSub, "BOTTOMLEFT", 0, -1)
+    local stackTxt = getglobal(stackChk:GetName() .. "Text")
+    if stackTxt then
+        stackTxt:SetText("Stack totals only while Shift is held")
+        stackTxt:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+    end
+    stackChk:SetScript("OnClick", function()
+        A.db.SetSetting("tipStackShift", stackChk:GetChecked() and true or false)
+    end)
+    ui.setTipStackShift = stackChk
 
     local profChk = CreateFrame("CheckButton", "AegisExchangeSetProfLine", panel,
         "UICheckButtonTemplate")
     profChk:SetWidth(24); profChk:SetHeight(24)
-    profChk:SetPoint("TOPLEFT", tipChk, "BOTTOMLEFT", 0, -4)
+    profChk:SetPoint("TOPLEFT", stackChk, "BOTTOMLEFT", -18, -4)
     local profTxt = getglobal(profChk:GetName() .. "Text")
     if profTxt then
         profTxt:SetText("Show profit line on profession windows")
@@ -824,8 +875,29 @@ function ui.RefreshSettings()
     if ui.setUndercutFlat then
         ui.setUndercutFlat:SetText(util.FormatMoney(A.db.Setting("undercutAmount"), false))
     end
+    local tipOn = A.db.Setting("tooltip") ~= false
     if ui.setTooltip then
-        ui.setTooltip:SetChecked(A.db.Setting("tooltip") ~= false and 1 or nil)
+        ui.setTooltip:SetChecked(tipOn and 1 or nil)
+    end
+    -- The per-line options are meaningless with the master switch off, so grey
+    -- them out rather than leaving them looking live.
+    if ui.setTipSubs then
+        local si = 1
+        while si <= table.getn(ui.setTipSubs) do
+            local c = ui.setTipSubs[si]
+            c:SetChecked(A.db.Setting(c.settingKey) ~= false and 1 or nil)
+            if tipOn then c:Enable() else c:Disable() end
+            si = si + 1
+        end
+    end
+    if ui.setTipStackShift then
+        ui.setTipStackShift:SetChecked(
+            A.db.Setting("tipStackShift") == true and 1 or nil)
+        if tipOn then
+            ui.setTipStackShift:Enable()
+        else
+            ui.setTipStackShift:Disable()
+        end
     end
     if ui.setProfLine then
         ui.setProfLine:SetChecked(A.db.Setting("profLine") ~= false and 1 or nil)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1102,6 +1102,116 @@ local function MakeMoneyBox(parent, width)
     return e
 end
 
+-- A gold / silver / copper triplet, the way the stock AH and aux present a
+-- price. Three small numeric boxes with coloured suffixes.
+--
+-- It deliberately EMULATES the single money box's interface (GetText / SetText
+-- / ClearFocus) so ReadMoneyBox, SetMoneyBox and every existing caller keep
+-- working untouched -- the Sell tab still thinks in plain copper everywhere,
+-- only the presentation changed.
+local function MakeMoneyGSC(parent, onChange)
+    local grp = {}
+    local function mk(w, suffix, r, g, b)
+        local e = CreateFrame("EditBox", nil, parent, "InputBoxTemplate")
+        e:SetWidth(w)
+        e:SetHeight(18)
+        e:SetAutoFocus(false)
+        e:SetNumeric(true)
+        e:SetJustifyH("RIGHT")
+        e:SetScript("OnEnterPressed", function() e:ClearFocus() end)
+        e:SetScript("OnEscapePressed", function() e:ClearFocus() end)
+        e:SetScript("OnTextChanged", function()
+            if grp.quiet then return end     -- our own SetText, not the user
+            if onChange then onChange() end
+        end)
+        local tag = parent:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+        tag:SetPoint("LEFT", e, "RIGHT", 2, 0)
+        tag:SetText(suffix)
+        tag:SetTextColor(r, g, b)
+        e.tag = tag
+        return e
+    end
+    grp.g = mk(34, "g", 1.00, 0.82, 0.00)
+    grp.s = mk(22, "s", 0.78, 0.78, 0.78)
+    grp.c = mk(22, "c", 0.80, 0.55, 0.35)
+
+    grp.GetText = function(self)
+        local gg = tonumber(self.g:GetText()) or 0
+        local ss = tonumber(self.s:GetText()) or 0
+        local cc = tonumber(self.c:GetText()) or 0
+        local total = gg * 10000 + ss * 100 + cc
+        if total <= 0 then return "" end
+        return util.FormatMoney(total, false)
+    end
+    grp.SetText = function(self, txt)
+        local copper = nil
+        if txt and txt ~= "" then copper = util.ParseMoney(txt) end
+        self.quiet = true
+        if not copper or copper <= 0 then
+            self.g:SetText(""); self.s:SetText(""); self.c:SetText("")
+        else
+            local gg, ss, cc = util.MoneyParts(copper)
+            self.g:SetText(gg > 0 and tostring(gg) or "")
+            self.s:SetText(tostring(ss))
+            self.c:SetText(tostring(cc))
+        end
+        self.quiet = false
+    end
+    grp.ClearFocus = function(self)
+        self.g:ClearFocus(); self.s:ClearFocus(); self.c:ClearFocus()
+    end
+    -- Anchor the whole triplet off one widget.
+    grp.Attach = function(self, anchor, dx, dy)
+        self.g:SetPoint("LEFT", anchor, "RIGHT", dx or 6, dy or 0)
+        self.s:SetPoint("LEFT", self.g.tag, "RIGHT", 5, 0)
+        self.c:SetPoint("LEFT", self.s.tag, "RIGHT", 5, 0)
+    end
+    return grp
+end
+
+-- Horizontal slider, hand-built from the base Slider widget for the same reason
+-- as the Aegis tab's scroll bar: Slider is a primitive that always exists, so
+-- there's no "Couldn't find inherited node" risk from guessing a 1.12 template.
+local function MakeHSlider(parent, width, onChange)
+    local sb = CreateFrame("Slider", nil, parent)
+    sb.aegisNoSkin = true
+    sb:SetWidth(width)
+    sb:SetHeight(15)
+    sb:SetOrientation("HORIZONTAL")
+    sb:SetMinMaxValues(1, 1)
+    sb:SetValue(1)
+    sb:SetValueStep(1)
+    sb:SetBackdrop({
+        bgFile = "Interface\\Buttons\\UI-SliderBar-Background",
+        edgeFile = "Interface\\Buttons\\UI-SliderBar-Border",
+        tile = true, tileSize = 8, edgeSize = 8,
+        insets = { left = 3, right = 3, top = 6, bottom = 6 },
+    })
+    local thumb = sb:CreateTexture(nil, "OVERLAY")
+    thumb:SetTexture("Interface\\Buttons\\UI-SliderBar-Button-Horizontal")
+    thumb:SetWidth(20)
+    thumb:SetHeight(20)
+    sb:SetThumbTexture(thumb)
+    sb:SetScript("OnValueChanged", function()
+        if ui.sellSliderSync then return end   -- we moved it, not the user
+        if onChange then onChange(this:GetValue()) end
+    end)
+    return sb
+end
+
+-- Point a slider at a range and value without its OnValueChanged firing back
+-- into the code that is currently painting the UI.
+local function SetSliderRange(sb, minV, maxV, value)
+    if not sb then return end
+    if maxV < minV then maxV = minV end
+    ui.sellSliderSync = true
+    sb:SetMinMaxValues(minV, maxV)
+    if value < minV then value = minV end
+    if value > maxV then value = maxV end
+    sb:SetValue(value)
+    ui.sellSliderSync = false
+end
+
 local function ReadMoneyBox(e)
     local txt = util.Trim(e:GetText() or "")
     if txt == "" then return nil end
@@ -3309,19 +3419,65 @@ function ui.BuildSellTab()
     ui.sellCap:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -44)
     ui.sellCap:SetJustifyH("RIGHT")
 
-    -- ---- Row 1: unit price + quick fills --------------------------------
+    -- ---- Row 1: stack size + stack count, each on a slider --------------
+    -- Sliders because picking a stack size is a "how do I want to split this"
+    -- decision, not a number you know up front -- dragging shows the trade-off
+    -- immediately, and the two are linked: a bigger stack means fewer of them.
+    local sizeLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    sizeLabel:SetPoint("TOPLEFT", slot, "BOTTOMLEFT", 0, -8)
+    sizeLabel:SetWidth(66)
+    sizeLabel:SetJustifyH("LEFT")
+    sizeLabel:SetText("Stack size:")
+    sizeLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
+
+    ui.sellStackSize = MakeNumBox(panel, 34, function()
+        ui.SyncSellPrices("size")
+    end)
+
+    ui.sellSizeSlider = MakeHSlider(panel, 104, function(v)
+        ui.sellStackSize:SetText(tostring(math.floor(v)))
+        ui.SyncSellPrices("size")
+    end)
+    ui.sellSizeSlider:SetPoint("LEFT", sizeLabel, "RIGHT", 6, 0)
+    ui.sellStackSize:SetPoint("LEFT", ui.sellSizeSlider, "RIGHT", 8, 0)
+
+    local cntLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    cntLabel:SetPoint("LEFT", ui.sellStackSize, "RIGHT", 16, 0)
+    cntLabel:SetText("Stacks:")
+    cntLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
+
+    ui.sellNumStacks = MakeNumBox(panel, 34, function() ui.RefreshSell() end)
+
+    ui.sellCountSlider = MakeHSlider(panel, 104, function(v)
+        ui.sellNumStacks:SetText(tostring(math.floor(v)))
+        ui.RefreshSell()
+    end)
+    ui.sellCountSlider:SetPoint("LEFT", cntLabel, "RIGHT", 6, 0)
+    ui.sellNumStacks:SetPoint("LEFT", ui.sellCountSlider, "RIGHT", 8, 0)
+
+    ui.sellMaxInfo = panel:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    ui.sellMaxInfo:SetPoint("LEFT", ui.sellNumStacks, "RIGHT", 10, 0)
+
+    -- ---- Row 2: bid / buyout per item, in gold-silver-copper -------------
+    local bidLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    bidLabel:SetPoint("TOPLEFT", sizeLabel, "BOTTOMLEFT", 0, -12)
+    bidLabel:SetWidth(76)
+    bidLabel:SetJustifyH("LEFT")
+    bidLabel:SetText("Bid / item:")
+    bidLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
+
+    -- Optional: left blank the start bid follows the buyout, which is what the
+    -- Sell tab has always done.
+    ui.sellBid = MakeMoneyGSC(panel, function() ui.RefreshSell() end)
+    ui.sellBid:Attach(bidLabel, 6, 0)
+
     local buyLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    buyLabel:SetPoint("TOPLEFT", slot, "BOTTOMLEFT", 0, -8)
-    buyLabel:SetWidth(82)
-    buyLabel:SetJustifyH("LEFT")
-    buyLabel:SetText("Unit price:")
+    buyLabel:SetPoint("LEFT", ui.sellBid.c.tag, "RIGHT", 18, 0)
+    buyLabel:SetText("Buy / item:")
     buyLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
 
-    ui.sellBuyout = MakeMoneyBox(panel, 92)
-    ui.sellBuyout:SetPoint("LEFT", buyLabel, "RIGHT", 6, 0)
-    ui.sellBuyout:SetScript("OnTextChanged", function()
-        ui.SyncSellPrices("unit")
-    end)
+    ui.sellBuyout = MakeMoneyGSC(panel, function() ui.SyncSellPrices("unit") end)
+    ui.sellBuyout:Attach(buyLabel, 6, 0)
 
     local mkQuick = function(text, w, anchorTo, fn)
         local b = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
@@ -3332,53 +3488,35 @@ function ui.BuildSellTab()
         b:SetScript("OnClick", fn)
         return b
     end
-    ui.sellMarketBtn = mkQuick("Market", 54, ui.sellBuyout, function()
+    -- These write through SetText, which stays quiet so the boxes don't fire
+    -- while we're filling them -- so each one re-syncs explicitly afterwards.
+    ui.sellMarketBtn = mkQuick("Market", 54, ui.sellBuyout.c.tag, function()
         local it = A.sell.GetItem()
         local sg = it and A.sell.Suggest(it.itemId)
-        if sg and sg.market then SetMoneyBox(ui.sellBuyout, sg.market) end
+        if sg and sg.market then
+            SetMoneyBox(ui.sellBuyout, sg.market)
+            ui.SyncSellPrices("unit")
+        end
     end)
     ui.sellUnderBtn = mkQuick("Undercut", 62, ui.sellMarketBtn, function()
         local it = A.sell.GetItem()
         local u = it and A.sell.UndercutUnit(it.itemId)
-        if u then SetMoneyBox(ui.sellBuyout, u) end
+        if u then
+            SetMoneyBox(ui.sellBuyout, u)
+            ui.SyncSellPrices("unit")
+        end
     end)
     ui.sellVendorBtn = mkQuick("Vendor", 52, ui.sellUnderBtn, function()
         local it = A.sell.GetItem()
         local sg = it and A.sell.Suggest(it.itemId)
-        if sg and sg.vendor then SetMoneyBox(ui.sellBuyout, sg.vendor) end
+        if sg and sg.vendor then
+            SetMoneyBox(ui.sellBuyout, sg.vendor)
+            ui.SyncSellPrices("unit")
+        end
     end)
-
-    -- ---- Row 2: stack price + "N stacks of S" ---------------------------
-    local stackLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    stackLabel:SetPoint("TOPLEFT", buyLabel, "BOTTOMLEFT", 0, -10)
-    stackLabel:SetWidth(82)
-    stackLabel:SetJustifyH("LEFT")
-    stackLabel:SetText("Stack price:")
-    stackLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
-
-    ui.sellStackPrice = MakeMoneyBox(panel, 92)
-    ui.sellStackPrice:SetPoint("LEFT", stackLabel, "RIGHT", 6, 0)
-    ui.sellStackPrice:SetScript("OnTextChanged", function()
-        ui.SyncSellPrices("stack")
-    end)
-
-    ui.sellNumStacks = MakeNumBox(panel, 34, function() ui.RefreshSell() end)
-    ui.sellNumStacks:SetPoint("LEFT", ui.sellStackPrice, "RIGHT", 12, 0)
-    local ofLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    ofLabel:SetPoint("LEFT", ui.sellNumStacks, "RIGHT", 4, 0)
-    ofLabel:SetText("stacks of")
-    ofLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
-    ui.sellStackSize = MakeNumBox(panel, 34, function()
-        ui.SyncSellPrices("size")
-    end)
-    ui.sellStackSize:SetPoint("LEFT", ofLabel, "RIGHT", 4, 0)
-
-    ui.sellMaxInfo = panel:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
-    ui.sellMaxInfo:SetPoint("LEFT", ui.sellStackSize, "RIGHT", 8, 0)
-
     -- ---- Row 3: duration + Post + Skip + status -------------------------
     local durLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    durLabel:SetPoint("TOPLEFT", stackLabel, "BOTTOMLEFT", 0, -12)
+    durLabel:SetPoint("TOPLEFT", bidLabel, "BOTTOMLEFT", 0, -12)
     durLabel:SetText("Duration:")
     durLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
 
@@ -4048,8 +4186,17 @@ function ui.RefreshSell()
         nStacks = maxStacks
         ui.sellNumStacks:SetText(tostring(nStacks))
     end
-    ui.sellMaxInfo:SetText(string.format("max %d stack(s) of %d",
-        maxStacks, size))
+    ui.sellMaxInfo:SetText(string.format("= %d of %d", size * nStacks, totalHave))
+
+    -- Re-range both sliders. Stack size can't exceed the item's own max stack
+    -- or what you actually hold; the count follows from whatever size is
+    -- chosen, which is what makes dragging one move the other's ceiling.
+    local sizeMax = totalHave
+    if it.maxStack and sizeMax > it.maxStack then sizeMax = it.maxStack end
+    if sizeMax < 1 then sizeMax = 1 end
+    SetSliderRange(ui.sellSizeSlider, 1, sizeMax, size)
+    SetSliderRange(ui.sellCountSlider, 1, (maxStacks >= 1) and maxStacks or 1,
+        nStacks)
 
     -- Totals across all stacks being posted.
     local stackTotal = unitBuy and math.floor(unitBuy * size) or 0
@@ -4122,21 +4269,16 @@ function ui.GetNumStacks()
     return NumVal(ui.sellNumStacks, 1)
 end
 
--- Keep unit price and stack price in step. `source` says which the user just
--- edited: "unit"/"size" -> recompute stack price; "stack" -> recompute unit.
+-- Repaint after a price or stack-size change.
+--
+-- Prices are now entered PER ITEM only. The editable stack-price box is gone --
+-- with a stack-size slider it was a second way to say the same thing, and the
+-- two boxes rounding into each other made a price drift as you dragged. The
+-- stack total is shown instead, on the right, by RefreshSell. `source` is kept
+-- so callers read the same as before.
 function ui.SyncSellPrices(source)
     if ui.sellSyncing then return end
     ui.sellSyncing = true
-    local size = ui.GetStackSize()
-    if source == "stack" then
-        local sp = ReadMoneyBox(ui.sellStackPrice)
-        if sp and size > 0 then
-            SetMoneyBox(ui.sellBuyout, math.floor(sp / size))
-        end
-    else
-        local u = ReadMoneyBox(ui.sellBuyout)
-        if u then SetMoneyBox(ui.sellStackPrice, u * size) end
-    end
     ui.sellSyncing = false
     ui.RefreshSell()
 end
@@ -4563,7 +4705,7 @@ function ui.SkipSell()
     ui.sellListingGroups = nil
     ui.sellScanState = nil
     SetMoneyBox(ui.sellBuyout, nil)
-    SetMoneyBox(ui.sellStackPrice, nil)
+    SetMoneyBox(ui.sellBid, nil)
     ui.UpdateListingsList()
     -- Walking the post-scan list? Move on to the next item.
     if ui.sellQueue and ui.AdvanceSellQueue() then return end
@@ -4587,13 +4729,20 @@ function ui.ConfirmPost()
         return
     end
     local unitBuy = ReadMoneyBox(ui.sellBuyout)
+    -- Bid is optional: blank means "same as the buyout", which is what the Sell
+    -- tab has always done. A bid above the buyout is a typo, not an intent.
+    local unitBid = ReadMoneyBox(ui.sellBid)
+    if unitBid and unitBuy and unitBid > unitBuy then
+        ChatMsg("Aegis: the bid per item can't be above the buyout.")
+        return
+    end
     local size    = ui.GetStackSize(it)
     local nStacks = ui.GetNumStacks()
     local maxStacks = A.sell.MaxStacks(it.itemId, size)
     if nStacks > maxStacks then nStacks = maxStacks end
     local stackBuyout = math.floor((unitBuy or 0) * size)
     if stackBuyout < 1 then
-        ChatMsg("Aegis: enter a unit price of at least 1 copper.")
+        ChatMsg("Aegis: enter a buyout per item of at least 1 copper.")
         return
     end
     if nStacks < 1 then
@@ -4616,7 +4765,8 @@ function ui.ConfirmPost()
         util.FormatMoney(perStack * nStacks))
     ui.pendingPost = {
         itemId = it.itemId, itemName = it.name, size = size,
-        nStacks = nStacks, unitBuyout = unitBuy, minutes = ui.sellDuration,
+        nStacks = nStacks, unitBuyout = unitBuy, unitBid = unitBid,
+        minutes = ui.sellDuration,
     }
     StaticPopup_Show("AEGIS_EXCHANGE_POST", it.name, detail)
 end
@@ -4627,7 +4777,7 @@ function ui.DoPost()
     ui.pendingPost = nil
     ui.sellStatus:SetText("Posting...")
     local ok, err = A.sell.StartPosting(p.itemId, p.itemName, p.size,
-        p.nStacks, p.unitBuyout, p.unitBuyout, p.minutes, {
+        p.nStacks, p.unitBuyout, p.unitBid or p.unitBuyout, p.minutes, {
             onProgress = function(done, total)
                 ui.sellStatus:SetText("Posting " .. done .. " / " .. total
                     .. "...")

--- a/ui/tooltip.lua
+++ b/ui/tooltip.lua
@@ -37,36 +37,48 @@ tooltip.hooked = false
 
 -- Append the Aegis price lines for `itemId` to `gtt` and re-flow it.
 -- AddLine/AddDoubleLine do NOT re-layout on their own — Show() is mandatory.
+-- A per-line toggle from the Aegis tab. Unset counts as ON, so a save written
+-- before these existed keeps showing everything.
+local function Want(key)
+    if not A.db.Setting then return true end
+    return A.db.Setting(key) ~= false
+end
+
 function tooltip.Extend(gtt, itemId, count)
     -- Honour the Aegis-tab toggle for tooltip price lines.
     if A.db.Setting and A.db.Setting("tooltip") == false then return end
-    local market = A.db.MarketValue(itemId)
-    local minBuy = A.db.MinBuyout(itemId)
-    local vendor = A.db.GetVendor(itemId)
+    local market = Want("tipMarket")    and A.db.MarketValue(itemId) or nil
+    local minBuy = Want("tipMinBuyout") and A.db.MinBuyout(itemId)   or nil
+    local vendor = Want("tipVendor")    and A.db.GetVendor(itemId)   or nil
     if not market and not minBuy and not vendor then return end
 
+    -- Stack totals: always, or only while Shift is held. Holding Shift is the
+    -- familiar gesture for "show me the whole stack" and keeps the tooltip
+    -- short when every bag slot is a stack of 20.
+    local withStack = count and count > 1
+    if withStack and A.db.Setting
+        and A.db.Setting("tipStackShift") == true then
+        withStack = IsShiftKeyDown and IsShiftKeyDown() and true or false
+    end
+    local function money(unit)
+        local right = util.FormatMoney(unit, true)
+        if withStack then
+            right = right .. " (x" .. count .. " = "
+                .. util.FormatMoney(unit * count, true) .. ")"
+        end
+        return right
+    end
+
     if market then
-        gtt:AddDoubleLine("Aegis Market",
-            util.FormatMoney(market, true),
+        gtt:AddDoubleLine("Aegis Market", money(market),
             ACCENT_R, ACCENT_G, ACCENT_B, 1, 1, 1)
     end
     if minBuy then
-        local right = util.FormatMoney(minBuy, true)
-        if count and count > 1 then
-            -- Per-unit price, then the whole-stack total, per the mockup.
-            right = right .. " (x" .. count .. " = "
-                .. util.FormatMoney(minBuy * count, true) .. ")"
-        end
-        gtt:AddDoubleLine("Aegis Min Buyout", right,
+        gtt:AddDoubleLine("Aegis Min Buyout", money(minBuy),
             ACCENT_R, ACCENT_G, ACCENT_B, 1, 1, 1)
     end
     if vendor then
-        local right = util.FormatMoney(vendor, true)
-        if count and count > 1 then
-            right = right .. " (x" .. count .. " = "
-                .. util.FormatMoney(vendor * count, true) .. ")"
-        end
-        gtt:AddDoubleLine("Aegis Vendor Price", right,
+        gtt:AddDoubleLine("Aegis Vendor Price", money(vendor),
             ACCENT_R, ACCENT_G, ACCENT_B, 1, 1, 1)
     end
     gtt:Show()
@@ -129,6 +141,88 @@ function resolvers.SetInboxItem(index)
     return id, count or 1
 end
 
+-- The surfaces below are the "is this worth picking up / is this worth making"
+-- ones. Every getter is probed before use: HookMethod already skips a tooltip
+-- method the client doesn't have, but a method can exist while its link getter
+-- doesn't, so each resolver guards its own.
+
+function resolvers.SetLootItem(slot)
+    if not GetLootSlotLink then return nil end
+    local id = util.ItemIdFromLink(GetLootSlotLink(slot))
+    if not id then return nil end
+    local count = 1
+    if GetLootSlotInfo then
+        local _, _, quantity = GetLootSlotInfo(slot)
+        count = quantity or 1
+    end
+    return id, count
+end
+
+function resolvers.SetQuestItem(qtype, slot)
+    if not GetQuestItemLink then return nil end
+    local id = util.ItemIdFromLink(GetQuestItemLink(qtype, slot))
+    if not id then return nil end
+    local count = 1
+    if GetQuestItemInfo then
+        local _, _, numItems = GetQuestItemInfo(qtype, slot)
+        count = numItems or 1
+    end
+    return id, count
+end
+
+function resolvers.SetQuestLogItem(qtype, slot)
+    if not GetQuestLogItemLink then return nil end
+    local id = util.ItemIdFromLink(GetQuestLogItemLink(qtype, slot))
+    if not id then return nil end
+    return id, 1
+end
+
+-- Tradeskill and Craft share a shape: with a slot it's a reagent, without one
+-- it's the thing being made. Pairs with the Crafting tab's profit line -- hover
+-- a reagent and see what it's worth without leaving the profession window.
+function resolvers.SetTradeSkillItem(skill, slot)
+    local link, count = nil, 1
+    if slot then
+        if not GetTradeSkillReagentItemLink then return nil end
+        link = GetTradeSkillReagentItemLink(skill, slot)
+        if GetTradeSkillReagentInfo then
+            local _, _, n = GetTradeSkillReagentInfo(skill, slot)
+            count = n or 1
+        end
+    else
+        if not GetTradeSkillItemLink then return nil end
+        link = GetTradeSkillItemLink(skill)
+    end
+    local id = util.ItemIdFromLink(link)
+    if not id then return nil end
+    return id, count
+end
+
+function resolvers.SetCraftItem(skill, slot)
+    local link, count = nil, 1
+    if slot then
+        if not GetCraftReagentItemLink then return nil end
+        link = GetCraftReagentItemLink(skill, slot)
+        if GetCraftReagentInfo then
+            local _, _, n = GetCraftReagentInfo(skill, slot)
+            count = n or 1
+        end
+    else
+        if not GetCraftItemLink then return nil end
+        link = GetCraftItemLink(skill)
+    end
+    local id = util.ItemIdFromLink(link)
+    if not id then return nil end
+    return id, count
+end
+
+function resolvers.SetCraftSpell(slot)
+    if not GetCraftItemLink then return nil end
+    local id = util.ItemIdFromLink(GetCraftItemLink(slot))
+    if not id then return nil end
+    return id, 1
+end
+
 -- ---------------------------------------------------------------------------
 -- Hook installation
 -- ---------------------------------------------------------------------------
@@ -176,6 +270,12 @@ function tooltip.Install()
     HookMethod("SetHyperlink",       "link")
     HookMethod("SetMerchantItem",    "merchant")
     HookMethod("SetInboxItem",       "inbox")
+    HookMethod("SetLootItem",        "loot")
+    HookMethod("SetQuestItem",       "quest")
+    HookMethod("SetQuestLogItem",    "questlog")
+    HookMethod("SetTradeSkillItem",  "tradeskill")
+    HookMethod("SetCraftItem",       "craft")
+    HookMethod("SetCraftSpell",      "craft")
 
     -- Vendor-price collection. 1.12's GetItemInfo has no sell price; the only
     -- source is the money line the client adds to bag-item tooltips while a


### PR DESCRIPTION
Fresh PR — #62 merged through v1.1.8, so this is the two commits that landed after it. `/reload`-safe.

| Commit | |
|---|---|
| `c242391` | Stack-size sliders + gold/silver/copper price entry |
| `928b15c` | More tooltip surfaces + per-line options |

Both are folded into **1.1.9** since it never shipped — no phantom version.

---

## Sell tab

**Sliders for stack size and count, interlocked.** Drag the size and the count's ceiling follows, because bigger stacks means fewer of them. Size stops at the item's own max stack *or* what you're actually carrying, whichever is smaller — so the UI can't offer a stack the game won't allow. The line beside them reads `= 27 of 28`: what you're about to list, against what you hold.

**Prices in gold / silver / copper**, one box each, like the stock AH. **Bid per item** is now its own field; blank still means "bid follows buyout", exactly as before.

The g/s/c triplet **emulates the old single money box's interface** (`GetText`/`SetText`/`ClearFocus`), so `ReadMoneyBox`, `SetMoneyBox`, the auto-prefill, the listing-row click and the post path all kept working untouched. Twelve call sites, none edited — the tab still thinks in plain copper everywhere, only the presentation changed.

> **One removal you didn't ask for:** the editable **stack price** box is gone. With a size slider it was a second way to say the same thing, and the two boxes rounding into each other made the price drift as you dragged. The stack total still shows on the right (`3 x 16s 92c = 50s 76c`). Easy to put back if you'd rather keep it.

## Tooltips

Now price **loot windows, quest rewards, the quest log and profession reagents** on top of bags, inventory, the AH, merchants and the mailbox. Hovering a reagent in a profession window pairs directly with the Crafting tab's profit line.

Because that's a lot more places for three extra lines to show up, the **Aegis tab now decides which ones do** — Market value, Minimum buyout and Vendor price toggle independently, and grey out when the master tooltip switch is off.

Plus **"Stack totals only while Shift is held"** — off by default, so nothing changes unless you want it. On, you get the unit price and only see `(x20 = 24g)` while Shift is down, which keeps tooltips short in a bank full of stacks. (aux defaults the other way; I kept our current behaviour as the default and made theirs opt-in.)

Each new resolver **probes its own link getter** before calling it. `HookMethod` already skips a tooltip method the client lacks, but a method can exist while its getter doesn't — and an unguarded call there is a runtime error on somebody else's client rather than ours.

## Inspiration from aux 

Reference only, per CLAUDE.md — aux is All Rights Reserved, so this is technique, never ported code.

- ✅ **`SlotLocked`** (shipped in v1.1.8's sibling commit): `GetContainerItemInfo`'s third return is `locked`, set while the server is still moving an item. Splitting out of a locked slot is silently dropped — the assembler now waits instead of burning a retry.
- ✅ **Shift-for-stack-totals** and the wider surface list, above.
- ⏳ **`ERR_AUCTION_STARTED` confirmation.** aux waits for that system message before counting a post; we increment as soon as `StartAuction` returns. A genuine correctness gap, but it touches the posting loop you just confirmed working — own PR.
- ⏳ **Merging, not just splitting.** aux builds a target stack from either direction (5+5 → 10); we only carve downward. `MaxStacks` reports that honestly, so it's consistent, just less capable.
- ❌ **The autopricing heuristic.** ~100 lines of tuned constants that can *refuse to post* and tell you to disenchant or vendor instead. Aegis's undercut rules are predictable and yours; swapping in someone else's opinionated model isn't an upgrade.

## Verification

`luac5.1 -p` clean on all 10 files; suite green. Seven sabotages across the two commits to confirm the tests bite:

| Sabotage | Assertion that fired |
|---|---|
| size slider ignores `maxStack` | `stack size caps at the item's max stack (20)…got 1..28` |
| count slider never re-ranges | `28 in one slot yields 2 stacks of 10, got 1` |
| g/s/c split collapses to copper | `a copper amount splits across the three boxes, got /0/123456` |
| per-line options ignored | `market line off -> 2 lines, got 3` |
| Shift setting ignored | `shift-only: no stack total without Shift` |
| new surfaces unhooked | `loot slot priced, got 0` |
| link getter unguarded | `a missing link getter does not error` |

Also found and removed a harness bug on the way: the tradeskill/craft reagent getters I'd added were **duplicates** — the crafting-capture fixtures already model them further down, and being defined later those won, so my copies were dead code silently doing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_