### PR TITLE
v1.2.0 — Sell tab in two columns, window scale, coin entry for the flat undercut

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.1.9
+## Version: 1.2.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,48 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.2.0]
+
+### Added
+- **Window scale** (Aegis tab). Resizing and scaling answer different questions:
+  a taller window shows *more rows* — vanilla frames never reflow, so that is
+  all it can do — while scale makes the same window physically bigger or
+  smaller. On a large monitor you want both. Steps of 5% between 70% and 150%,
+  with a Reset, remembered per character.
+- **Price match** alongside **Undercut** on the Sell tab. Undercut works from
+  the competition's price with your undercut rule applied; Price match uses
+  that same reference price untouched, for when you would rather sit level with
+  the cheapest seller than start a race to the bottom.
+
+### Changed
+- **The Sell tab is two columns.** The left half is *what am I posting* — both
+  sliders stacked, duration under them; the right half is *for how much* — the
+  two pricing buttons above the bid and buyout rows they write into. They used
+  to interleave on shared rows, which meant reading a price and reading a stack
+  size were the same eye movement.
+- **The flat undercut is entered in gold / silver / copper**, the same widget
+  the Sell tab's bid and buyout use, instead of typing `1s 50c` into a text
+  box. One way to type a price everywhere in the addon.
+- The Sell tab's **History block is gone**. The scan median, minimum buyout and
+  vendor price still sit on the line under the item name, and what things have
+  actually sold for lives on the History tab.
+- The posting status line moved to its own row under the buttons — squeezed
+  onto the duration row it had about 160px before it ran into the price column,
+  which is not enough for `Item 7 of 23 — Elemental Earth`.
+- Minimum window height is 472 (was 460), so the roomier Sell controls do not
+  cost the smallest window a row in its lists.
+
+### Fixed
+- **A taller window now fills with rows instead of growing around them.**
+  Releasing the resize grip refreshed the scan strip but never repainted the
+  open tab, so every list kept the row count it was last drawn with and the
+  extra height went to empty space (or, in the bag list, to more scrolling).
+- A saved window scale is re-applied on login even when the window was never
+  resized — the two are stored independently, and restoring bailed out early
+  when there was no saved size.
+
+---
+
 ## [1.1.9]
 
 ### Added
@@ -466,6 +508,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.2.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.9]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.8]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.1.7]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.1.9)
+# Aegis: Exchange (v1.2.0)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -62,16 +62,18 @@ need (all your tailoring mats, say) and search the whole list in one click.
 
 ### 💰 Sell — price it right the first time
 Drop an item in and Aegis scans the AH for *just that item*, shows you every
-competing listing, and pre-fills your price. **Undercut** by a percentage or a
-flat amount (yes, 1 copper works). Post **multiple stacks at once** — "3 stacks
-of 20" — with an approximate deposit and your listing count against the 120-auction
-cap. Click any competitor's row to steal their price.
+competing listing, and pre-fills your price. Two columns: on the left *what
+you're posting* — stack size and stack count on interlocking sliders, duration
+underneath; on the right *for how much* — **Undercut** (by a percentage or a
+flat amount; yes, 1 copper works) or **Price match** to sit level with the
+cheapest seller, above bid and buyout in gold / silver / copper.
 
-A **History** panel shows what your scans say the item is worth (median, the
-range you've seen, how many days of data) next to what it has **actually sold
-for** from your mailbox. And after a **bag scan**, Aegis loads the first item
-into the sell slot and walks you down the list — **Post** or **Skip** moves to
-the next one, so you can clear a full bag without clicking back and forth.
+Post **multiple stacks at once** — "3 stacks of 20" — with an approximate
+deposit and your listing count against the 120-auction cap. Click any
+competitor's row to steal their price. And after a **bag scan**, Aegis loads the
+first item into the sell slot and walks you down the list — **Post** or **Skip**
+moves to the next one, so you can clear a full bag without clicking back and
+forth.
 
 ### 🏪 Vendor list — some things just aren't worth listing
 Not everything belongs on the auction house. Hit **Vendor** on the Sell tab and
@@ -111,16 +113,17 @@ records every "Auction successful" for you. Purchases get logged when you buy.
 Then it tells you **Income · Spent · Net** over the last 24h, 7d, 30d, or all
 time.
 
-### 🪟 Resize it
-Drag the grip in the bottom-right corner. The lists re-fit as you drag, so a
-taller window shows **more rows** rather than more blank space. Your size is
-remembered per character.
+### 🪟 Resize it — or scale it
+Drag the grip in the bottom-right corner. The lists re-fit as you let go, so a
+taller window shows **more rows** rather than more blank space. Vanilla frames
+never reflow, so that's all size can do — for *bigger*, there's a **window
+scale** on the Aegis tab (70%–150%). Both are remembered per character.
 
 ### 🔍 Aegis tab — scanning + settings
 Run a full scan, a category-targeted scan, or scan everything in your bags to
 price it. Pause, resume, or **stop** whenever. Plus your defaults: post duration,
-undercut rule (% or flat), auto-fill price, tooltip lines, profit line, and the
-pfUI skin — all in one place.
+undercut rule (% or flat, entered in coins), auto-fill price, window scale,
+tooltip lines, profit line, and the pfUI skin — all in one place.
 
 ### 💬 Tooltips everywhere
 Bags, inventory, the auction house, merchants, the mailbox, **loot windows,
@@ -246,7 +249,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.1.9`) — quote it.
+1. Check the **version** in the window's title bar (`v1.2.0`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.1.9"
+A.version = "1.2.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/sell.lua
+++ b/core/sell.lua
@@ -305,20 +305,24 @@ local function ApplyUndercut(ref)
     return under
 end
 
+-- The price the competition is asking, per unit -- the reference both pricing
+-- buttons work from. Prefer the freshest thing we have: the lowest OTHER
+-- seller from the last item scan; else the DB's min buyout / market.
+-- Returns copper, or nil if we have no data for the item.
+function sell.MatchUnit(itemId)
+    local low = sell.LowestListingUnit(true)
+    if low and low > 1 then return low end
+    local s = sell.Suggest(itemId)
+    if not s then return nil end
+    return s.minBuyout or s.market
+end
+
 -- Per-unit price to undercut the cheapest seen buyout (falls back to market
 -- value). Returns copper, or nil if we have no data for the item.
 function sell.UndercutUnit(itemId)
-    -- Prefer the freshest thing we have: the lowest OTHER seller from the last
-    -- item scan; else the DB's min buyout / market. Both get the same percent.
-    local low = sell.LowestListingUnit(true)
-    if low and low > 1 then
-        return ApplyUndercut(low)
-    end
-    local s = sell.Suggest(itemId)
-    if not s then return nil end
-    local base = s.minBuyout or s.market
-    if not base then return nil end
-    return ApplyUndercut(base)
+    local ref = sell.MatchUnit(itemId)
+    if not ref then return nil end
+    return ApplyUndercut(ref)
 end
 
 -- ---------------------------------------------------------------------------

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -44,11 +44,21 @@ local C = {
 -- Last scan older than this is "stale" and rendered amber.
 local STALE_SECONDS = 24 * 60 * 60
 
+-- Forward declarations: these are defined further down with the other
+-- widget helpers, but ui.BuildAegisSettings is written above that point
+-- and a local is only in scope after its declaration.
+local MakeMoneyGSC, MakeHSlider, SetSliderRange
+
 -- Window size bounds. The minimum is the old fixed size -- below it the Sell
 -- tab's header rows start colliding -- and the maximum is generous enough for
 -- a big monitor without letting the window escape a small one.
-local MIN_W, MIN_H = 832, 460
+local MIN_W, MIN_H = 832, 472
 local MAX_W, MAX_H = 1400, 900
+
+-- Height of the Sell tab's control block -- everything above the divider. The
+-- bag list and the listings table both hang off it, so the whole tab shifts
+-- together when the controls change.
+local SELL_TOP_H = 146
 
 -- Sub-tab order, left to right. "Scan" hosts the scanner controls (Full Scan /
 -- Pause / Resume / Stop / Categories + status and progress) and the settings
@@ -106,6 +116,10 @@ end
 
 function ui.RestoreWindowSize()
     if not ui.frame or not A.db or not A.db.char then return end
+    -- Scale first, and unconditionally: it is stored independently of the size,
+    -- so someone who scaled the window but never dragged it bigger has no saved
+    -- width to restore -- and would otherwise lose their scale every login.
+    ui.ApplyWindowScale()
     local s = A.db.char.ui
     if not s or not s.width or not s.height then return end
     local w, h = s.width, s.height
@@ -115,6 +129,57 @@ function ui.RestoreWindowSize()
     if h > MAX_H then h = MAX_H end
     ui.frame:SetWidth(w)
     ui.frame:SetHeight(h)
+end
+
+-- ---------------------------------------------------------------------------
+-- Window scale
+--
+-- Resizing and scaling answer different questions. A taller window shows MORE
+-- rows (vanilla frames never reflow, so that is all it can do); scale makes
+-- the same window physically bigger or smaller. On a 4K screen you want both:
+-- more rows AND text you can read.
+--
+-- Stored per character alongside the size, and clamped -- below ~0.6 the
+-- fonts stop being legible and above ~1.5 the window no longer fits a 1024-
+-- tall screen at MAX_H.
+-- ---------------------------------------------------------------------------
+
+local SCALE_MIN, SCALE_MAX, SCALE_STEP = 0.70, 1.50, 0.05
+
+function ui.WindowScale()
+    if not A.db or not A.db.char then return 1 end
+    local s = A.db.char.ui
+    local v = s and s.scale
+    if not v or v < SCALE_MIN then return 1 end
+    if v > SCALE_MAX then return SCALE_MAX end
+    return v
+end
+
+-- Push the stored scale onto the window. Safe to call before the DB exists.
+function ui.ApplyWindowScale()
+    if not ui.frame or not ui.frame.SetScale then return end
+    ui.frame:SetScale(ui.WindowScale())
+end
+
+-- Nudge the scale by `delta` (pass nil to reset to 1.0).
+function ui.StepWindowScale(delta)
+    if not A.db or not A.db.char then return end
+    local v = 1
+    if delta then
+        v = ui.WindowScale() + delta
+        -- Round to the step so repeated nudges can't drift off it.
+        v = math.floor(v * 100 + 0.5) / 100
+        if v < SCALE_MIN then v = SCALE_MIN end
+        if v > SCALE_MAX then v = SCALE_MAX end
+    end
+    local s = A.db.char.ui
+    if not s then s = {}; A.db.char.ui = s end
+    s.scale = v
+    ui.ApplyWindowScale()
+    -- No list repaint needed: scale leaves every measurement in frame units
+    -- exactly where it was, so the row fit and the text truncation are both
+    -- unchanged. Only the readout has to catch up.
+    ui.RefreshSettings()
 end
 
 -- Skin any rows in `pool` that were grown after the skin's one-shot pass.
@@ -326,7 +391,8 @@ function ui.BuildWindow()
         f.aegisSizing = false
         f:StopMovingOrSizing()
         ui.SaveWindowSize()
-        ui.Refresh()          -- re-fit every list to the new height
+        ui.Refresh()
+        ui.RefreshCurrentTab()   -- re-fit the visible list to the new height
     end)
     -- Deliberately NO per-frame refresh while dragging. Repainting mid-drag
     -- means calling FauxScrollFrame_Update with a row count that is changing
@@ -726,20 +792,26 @@ function ui.BuildAegisSettings(panel, anchorAbove)
     pctLbl:SetText("%")
     pctLbl:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
 
-    -- Flat-amount entry (money text like "1s" or "50c").
-    local flat = CreateFrame("EditBox", nil, panel, "InputBoxTemplate")
-    flat:SetWidth(64); flat:SetHeight(18)
-    flat:SetAutoFocus(false); flat:SetJustifyH("CENTER")
-    flat:SetPoint("LEFT", pctLbl, "RIGHT", 12, 0)
-    flat:SetScript("OnEnterPressed", function()
-        ui.CommitUndercutFlat(); flat:ClearFocus()
-    end)
-    flat:SetScript("OnEscapePressed", function() flat:ClearFocus() end)
-    flat:SetScript("OnEditFocusLost", function() ui.CommitUndercutFlat() end)
+    -- Flat-amount entry. A gold/silver/copper triplet, the same widget the Sell
+    -- tab uses for bid and buyout -- one way to type a price everywhere.
+    --
+    -- Committing on every keystroke would repaint the boxes from the stored
+    -- value while the user is still typing, so the live edits commit QUIETLY
+    -- and only losing focus (or pressing Enter) triggers the full repaint.
+    local flat = MakeMoneyGSC(panel, function() ui.CommitUndercutFlat(true) end)
+    flat:Attach(pctLbl, 12, 0)
+    local fbox = { flat.g, flat.s, flat.c }
+    local fi = 1
+    while fi <= 3 do
+        fbox[fi]:SetScript("OnEditFocusLost", function()
+            ui.CommitUndercutFlat()
+        end)
+        fi = fi + 1
+    end
     ui.setUndercutFlat = flat
     local flatLbl = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    flatLbl:SetPoint("LEFT", flat, "RIGHT", 4, 0)
-    flatLbl:SetText("below (e.g. 1s, 50c)")
+    flatLbl:SetPoint("LEFT", flat.c.tag, "RIGHT", 8, 0)
+    flatLbl:SetText("below")
     flatLbl:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
 
     -- ---- Default sell price -----------------------------------------------
@@ -766,11 +838,42 @@ function ui.BuildAegisSettings(panel, anchorAbove)
         mi = mi + 1
     end
 
+    -- ---- Window scale ------------------------------------------------------
+    -- Deliberately buttons rather than a slider. A slider that rescales the
+    -- window it lives on moves itself out from under the cursor mid-drag, and
+    -- the thumb then tracks to a different value -- a feedback loop. Discrete
+    -- steps have no such problem and are easier to land on a round number.
+    local scLbl = label("Window scale:", spLbl, -20)
+
+    local scDown = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+    scDown:SetWidth(24); scDown:SetHeight(20)
+    scDown:SetPoint("LEFT", scLbl, "RIGHT", 10, 0)
+    scDown:SetText("-")
+    scDown:SetScript("OnClick", function() ui.StepWindowScale(-SCALE_STEP) end)
+
+    ui.setScaleText = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    ui.setScaleText:SetPoint("LEFT", scDown, "RIGHT", 8, 0)
+    ui.setScaleText:SetWidth(40)
+    ui.setScaleText:SetJustifyH("CENTER")
+    ui.setScaleText:SetTextColor(C.text[1], C.text[2], C.text[3])
+
+    local scUp = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+    scUp:SetWidth(24); scUp:SetHeight(20)
+    scUp:SetPoint("LEFT", ui.setScaleText, "RIGHT", 8, 0)
+    scUp:SetText("+")
+    scUp:SetScript("OnClick", function() ui.StepWindowScale(SCALE_STEP) end)
+
+    local scReset = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+    scReset:SetWidth(56); scReset:SetHeight(20)
+    scReset:SetPoint("LEFT", scUp, "RIGHT", 10, 0)
+    scReset:SetText("Reset")
+    scReset:SetScript("OnClick", function() ui.StepWindowScale(nil) end)
+
     -- ---- Toggles ----------------------------------------------------------
     local tipChk = CreateFrame("CheckButton", "AegisExchangeSetTooltip", panel,
         "UICheckButtonTemplate")
     tipChk:SetWidth(24); tipChk:SetHeight(24)
-    tipChk:SetPoint("TOPLEFT", spLbl, "BOTTOMLEFT", -2, -16)
+    tipChk:SetPoint("TOPLEFT", scLbl, "BOTTOMLEFT", -2, -16)
     local tipTxt = getglobal(tipChk:GetName() .. "Text")
     if tipTxt then
         tipTxt:SetText("Show Aegis price lines on item tooltips")
@@ -940,12 +1043,16 @@ function ui.CommitUndercut()
 end
 
 -- Parse and store the flat-amount undercut (money text -> copper).
-function ui.CommitUndercutFlat()
+--
+-- `quiet` skips the repaint. The g/s/c boxes commit on every keystroke, and
+-- repainting them from the stored value mid-word would fight the typist; the
+-- full refresh happens when the field is left instead.
+function ui.CommitUndercutFlat(quiet)
     if not ui.setUndercutFlat then return end
     local c = util.ParseMoney(util.Trim(ui.setUndercutFlat:GetText() or ""))
     if not c or c < 1 then c = A.db.Setting("undercutAmount") end
     A.db.SetSetting("undercutAmount", math.floor(c))
-    ui.RefreshSettings()
+    if not quiet then ui.RefreshSettings() end
 end
 
 -- Push the saved default duration to the Sell tab immediately.
@@ -986,6 +1093,9 @@ function ui.RefreshSettings()
     end
     if ui.setUndercutFlat then
         ui.setUndercutFlat:SetText(util.FormatMoney(A.db.Setting("undercutAmount"), false))
+    end
+    if ui.setScaleText then
+        ui.setScaleText:SetText(math.floor(ui.WindowScale() * 100 + 0.5) .. "%")
     end
     local tipOn = A.db.Setting("tooltip") ~= false
     if ui.setTooltip then
@@ -1293,7 +1403,7 @@ end
 -- / ClearFocus) so ReadMoneyBox, SetMoneyBox and every existing caller keep
 -- working untouched -- the Sell tab still thinks in plain copper everywhere,
 -- only the presentation changed.
-local function MakeMoneyGSC(parent, onChange)
+MakeMoneyGSC = function(parent, onChange)
     local grp = {}
     -- Blizzard's own coin art, the same the stock money frame uses -- so a
     -- price here reads exactly like a price anywhere else in the game.
@@ -1370,7 +1480,7 @@ end
 -- Horizontal slider, hand-built from the base Slider widget for the same reason
 -- as the Aegis tab's scroll bar: Slider is a primitive that always exists, so
 -- there's no "Couldn't find inherited node" risk from guessing a 1.12 template.
-local function MakeHSlider(parent, width, onChange)
+MakeHSlider = function(parent, width, onChange)
     local sb = CreateFrame("Slider", nil, parent)
     sb.aegisNoSkin = true
     sb:SetWidth(width)
@@ -1399,7 +1509,7 @@ end
 
 -- Point a slider at a range and value without its OnValueChanged firing back
 -- into the code that is currently painting the UI.
-local function SetSliderRange(sb, minV, maxV, value)
+SetSliderRange = function(sb, minV, maxV, value)
     if not sb then return end
     if maxV < minV then maxV = minV end
     ui.sellSliderSync = true
@@ -3646,25 +3756,6 @@ function ui.BuildSellTab()
     ui.sellVendor:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -60)
     ui.sellVendor:SetJustifyH("RIGHT")
 
-    -- History block: what our SCAN history says this item is worth (the
-    -- time-weighted median of daily minimums, plus the observed range) and what
-    -- it has actually SOLD for (from the mailbox ledger). Sits between the
-    -- deposit info and the listings table.
-    local histHdr = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    histHdr:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -84)
-    histHdr:SetJustifyH("RIGHT")
-    histHdr:SetText("History")
-    histHdr:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
-    ui.sellHistHdr = histHdr
-
-    ui.sellHistScan = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    ui.sellHistScan:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -100)
-    ui.sellHistScan:SetJustifyH("RIGHT")
-
-    ui.sellHistSold = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    ui.sellHistSold:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -116)
-    ui.sellHistSold:SetJustifyH("RIGHT")
-
     -- Deposit / total / cap count, right-aligned.
     ui.sellDeposit = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
     ui.sellDeposit:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -12)
@@ -3680,12 +3771,18 @@ function ui.BuildSellTab()
     ui.sellCap:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -44)
     ui.sellCap:SetJustifyH("RIGHT")
 
-    -- ---- Row 1: stack size + stack count, each on a slider --------------
-    -- Sliders because picking a stack size is a "how do I want to split this"
-    -- decision, not a number you know up front -- dragging shows the trade-off
-    -- immediately, and the two are linked: a bigger stack means fewer of them.
+    -- ---- LEFT column: what to post --------------------------------------
+    -- Two stacked sliders and the duration under them. Sliders because picking
+    -- a stack size is a "how do I want to split this" decision, not a number
+    -- you know up front -- dragging shows the trade-off immediately, and the
+    -- two are linked: a bigger stack means fewer of them.
+    --
+    -- The split into columns is deliberate: the left half answers "what am I
+    -- putting up", the right half "for how much". They used to interleave on
+    -- shared rows, which meant reading a price and reading a stack size were
+    -- the same eye movement.
     local sizeLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    sizeLabel:SetPoint("TOPLEFT", slot, "BOTTOMLEFT", 0, -8)
+    sizeLabel:SetPoint("TOPLEFT", slot, "BOTTOMLEFT", 0, -6)
     sizeLabel:SetWidth(66)
     sizeLabel:SetJustifyH("LEFT")
     sizeLabel:SetText("Stack size:")
@@ -3703,7 +3800,9 @@ function ui.BuildSellTab()
     ui.sellStackSize:SetPoint("LEFT", ui.sellSizeSlider, "RIGHT", 8, 0)
 
     local cntLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    cntLabel:SetPoint("LEFT", ui.sellStackSize, "RIGHT", 16, 0)
+    cntLabel:SetPoint("TOPLEFT", sizeLabel, "BOTTOMLEFT", 0, -8)
+    cntLabel:SetWidth(66)
+    cntLabel:SetJustifyH("LEFT")
     cntLabel:SetText("Stacks:")
     cntLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
 
@@ -3719,65 +3818,9 @@ function ui.BuildSellTab()
     ui.sellMaxInfo = panel:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
     ui.sellMaxInfo:SetPoint("LEFT", ui.sellNumStacks, "RIGHT", 10, 0)
 
-    -- ---- Row 2: bid / buyout per item, in gold-silver-copper -------------
-    local bidLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    bidLabel:SetPoint("TOPLEFT", sizeLabel, "BOTTOMLEFT", 0, -12)
-    bidLabel:SetWidth(76)
-    bidLabel:SetJustifyH("LEFT")
-    bidLabel:SetText("Bid / item:")
-    bidLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
-
-    -- Optional: left blank the start bid follows the buyout, which is what the
-    -- Sell tab has always done.
-    ui.sellBid = MakeMoneyGSC(panel, function() ui.RefreshSell() end)
-    ui.sellBid:Attach(bidLabel, 6, 0)
-
-    local buyLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    buyLabel:SetPoint("LEFT", ui.sellBid.c.tag, "RIGHT", 18, 0)
-    buyLabel:SetText("Buy / item:")
-    buyLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
-
-    ui.sellBuyout = MakeMoneyGSC(panel, function() ui.SyncSellPrices("unit") end)
-    ui.sellBuyout:Attach(buyLabel, 6, 0)
-
-    local mkQuick = function(text, w, anchorTo, fn)
-        local b = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
-        b:SetWidth(w)
-        b:SetHeight(18)
-        b:SetPoint("LEFT", anchorTo, "RIGHT", 5, 0)
-        b:SetText(text)
-        b:SetScript("OnClick", fn)
-        return b
-    end
-    -- These write through SetText, which stays quiet so the boxes don't fire
-    -- while we're filling them -- so each one re-syncs explicitly afterwards.
-    ui.sellMarketBtn = mkQuick("Market", 54, ui.sellBuyout.c.tag, function()
-        local it = A.sell.GetItem()
-        local sg = it and A.sell.Suggest(it.itemId)
-        if sg and sg.market then
-            SetMoneyBox(ui.sellBuyout, sg.market)
-            ui.SyncSellPrices("unit")
-        end
-    end)
-    ui.sellUnderBtn = mkQuick("Undercut", 62, ui.sellMarketBtn, function()
-        local it = A.sell.GetItem()
-        local u = it and A.sell.UndercutUnit(it.itemId)
-        if u then
-            SetMoneyBox(ui.sellBuyout, u)
-            ui.SyncSellPrices("unit")
-        end
-    end)
-    ui.sellVendorBtn = mkQuick("Vendor", 52, ui.sellUnderBtn, function()
-        local it = A.sell.GetItem()
-        local sg = it and A.sell.Suggest(it.itemId)
-        if sg and sg.vendor then
-            SetMoneyBox(ui.sellBuyout, sg.vendor)
-            ui.SyncSellPrices("unit")
-        end
-    end)
-    -- ---- Row 3: duration + Post + Skip + status -------------------------
+    -- Duration, directly under the sliders.
     local durLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    durLabel:SetPoint("TOPLEFT", bidLabel, "BOTTOMLEFT", 0, -12)
+    durLabel:SetPoint("TOPLEFT", cntLabel, "BOTTOMLEFT", 0, -10)
     durLabel:SetText("Duration:")
     durLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
 
@@ -3827,27 +3870,100 @@ function ui.BuildSellTab()
     end)
     ui.sellSkipBtn = skip
 
+    -- Status gets its own line under the buttons. Squeezed onto the duration
+    -- row it had ~160px before it ran into the price column, which is not
+    -- enough for "Item 7 of 23 -- Elemental Earth".
     ui.sellStatus = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    ui.sellStatus:SetPoint("LEFT", skip, "RIGHT", 10, 0)
+    ui.sellStatus:SetPoint("TOPLEFT", durLabel, "BOTTOMLEFT", 0, -8)
     ui.sellStatus:SetJustifyH("LEFT")
     ui.sellStatus:SetTextColor(C.amber[1], C.amber[2], C.amber[3])
+
+    -- ---- RIGHT column: for how much -------------------------------------
+    -- Pricing shortcuts sit ABOVE the two money rows they write into, so the
+    -- reading order is "pick a strategy, see what it produced".
+    --
+    -- Two buttons, not three. Undercut and price-match are the only choices
+    -- that are actually about the market; "Market" was the same reference
+    -- price with no undercut applied (i.e. price-match with worse data) and
+    -- "Vendor" was a floor, not a strategy -- the vendor figure is still shown
+    -- in this column and the Vendor list still calls out items worth more to a
+    -- merchant than to the AH.
+    local mkQuick = function(text, w, fn)
+        local b = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+        b:SetWidth(w)
+        b:SetHeight(20)
+        b:SetText(text)
+        b:SetScript("OnClick", fn)
+        return b
+    end
+    -- These write through SetText, which stays quiet so the boxes don't fire
+    -- while we're filling them -- so each one re-syncs explicitly afterwards.
+    ui.sellMatchBtn = mkQuick("Price match", 84, function()
+        local it = A.sell.GetItem()
+        local m = it and A.sell.MatchUnit(it.itemId)
+        if m then
+            SetMoneyBox(ui.sellBuyout, m)
+            ui.SyncSellPrices("unit")
+        end
+    end)
+    ui.sellMatchBtn:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -12, -78)
+
+    ui.sellUnderBtn = mkQuick("Undercut", 70, function()
+        local it = A.sell.GetItem()
+        local u = it and A.sell.UndercutUnit(it.itemId)
+        if u then
+            SetMoneyBox(ui.sellBuyout, u)
+            ui.SyncSellPrices("unit")
+        end
+    end)
+    ui.sellUnderBtn:SetPoint("RIGHT", ui.sellMatchBtn, "LEFT", -5, 0)
+
+    -- Bid / buyout per item, in gold-silver-copper. Right-aligned as a block:
+    -- the copper box is the rightmost thing on each row, so the two rows line
+    -- up denominator for denominator.
+    --
+    -- Anchored from the RIGHT edge rather than off the buttons above: the
+    -- triplet plus its coin icons is 139px wide from the label, so hanging it
+    -- off the (narrower) button row would push the copper box off the panel.
+    local PRICE_GSC_W = 139
+    local bidLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    bidLabel:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -(PRICE_GSC_W + 12), -104)
+    bidLabel:SetWidth(66)
+    bidLabel:SetJustifyH("LEFT")
+    bidLabel:SetText("Bid / item:")
+    bidLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
+
+    -- Left blank, the start bid follows the buyout -- which is what the Sell
+    -- tab has always done.
+    ui.sellBid = MakeMoneyGSC(panel, function() ui.RefreshSell() end)
+    ui.sellBid:Attach(bidLabel, 6, 0)
+
+    local buyLabel = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    buyLabel:SetPoint("TOPLEFT", bidLabel, "BOTTOMLEFT", 0, -8)
+    buyLabel:SetWidth(66)
+    buyLabel:SetJustifyH("LEFT")
+    buyLabel:SetText("Buy / item:")
+    buyLabel:SetTextColor(C.text[1], C.text[2], C.text[3])
+
+    ui.sellBuyout = MakeMoneyGSC(panel, function() ui.SyncSellPrices("unit") end)
+    ui.sellBuyout:Attach(buyLabel, 6, 0)
 
     -- ---- Divider --------------------------------------------------------
     local div = panel:CreateTexture(nil, "ARTWORK")
     div:SetTexture(C.border[1], C.border[2], C.border[3], 0.4)
     div:SetHeight(1)
-    div:SetPoint("TOPLEFT", panel, "TOPLEFT", 8, -134)
-    div:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -8, -134)
+    div:SetPoint("TOPLEFT", panel, "TOPLEFT", 8, -SELL_TOP_H)
+    div:SetPoint("TOPRIGHT", panel, "TOPRIGHT", -8, -SELL_TOP_H)
 
     -- ---- Bottom-left: Your Bags ----------------------------------------
     local bagHdr = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    bagHdr:SetPoint("TOPLEFT", panel, "TOPLEFT", 12, -142)
+    bagHdr:SetPoint("TOPLEFT", panel, "TOPLEFT", 12, -(SELL_TOP_H + 8))
     bagHdr:SetText("Your Bags")
     bagHdr:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
 
     local bagScroll = CreateFrame("ScrollFrame", "AegisExchangeBagScroll",
         panel, "FauxScrollFrameTemplate")
-    bagScroll:SetPoint("TOPLEFT", panel, "TOPLEFT", 12, -160)
+    bagScroll:SetPoint("TOPLEFT", panel, "TOPLEFT", 12, -(SELL_TOP_H + 26))
     -- Right edge pulled well in (168) so the FauxScrollFrame's scrollbar, which
     -- sits just OUTSIDE this edge, clears the listings column that starts at
     -- x=200 -- otherwise the bar overlaps the price info.
@@ -3956,7 +4072,7 @@ ui.GrowBagRows = function(n)
 
     -- ---- Bottom-right: listings table ----------------------------------
     ui.listHeader = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    ui.listHeader:SetPoint("TOPLEFT", panel, "TOPLEFT", 200, -138)
+    ui.listHeader:SetPoint("TOPLEFT", panel, "TOPLEFT", 200, -(SELL_TOP_H + 4))
     ui.listHeader:SetJustifyH("LEFT")
     ui.listHeader:SetText("Select an item to see its listings")
     ui.listHeader:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
@@ -3970,7 +4086,7 @@ ui.GrowBagRows = function(n)
     ui.sellHeaders = {}
     local mkCol = function(x, text, key, width)
         local b = CreateFrame("Button", nil, panel)
-        b:SetPoint("TOPLEFT", panel, "TOPLEFT", x, -155)
+        b:SetPoint("TOPLEFT", panel, "TOPLEFT", x, -(SELL_TOP_H + 21))
         b:SetHeight(16)
         b.aegisNoSkin = true
         local fs = b:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
@@ -3994,7 +4110,7 @@ ui.GrowBagRows = function(n)
 
     local listScroll = CreateFrame("ScrollFrame", "AegisExchangeListScroll",
         panel, "FauxScrollFrameTemplate")
-    listScroll:SetPoint("TOPLEFT", panel, "TOPLEFT", 200, -170)
+    listScroll:SetPoint("TOPLEFT", panel, "TOPLEFT", 200, -(SELL_TOP_H + 36))
     listScroll:SetPoint("BOTTOMRIGHT", panel, "BOTTOMRIGHT", -26, 10)
     listScroll:SetScript("OnVerticalScroll", function()
         FauxScrollFrame_OnVerticalScroll(LIST_ROW_H, ui.UpdateListingsList)
@@ -4408,8 +4524,6 @@ function ui.RefreshSell()
         ui.sellDeposit:SetText("")
         ui.sellTotal:SetText("")
         ui.sellMaxInfo:SetText("")
-        ui.sellHistScan:SetText("")
-        ui.sellHistSold:SetText("")
         ui.sellPostBtn:Disable()
         ui.lastScanItemId = nil
         ui.sellDefaultsFor = nil
@@ -4452,8 +4566,6 @@ function ui.RefreshSell()
     else
         ui.sellCtx:SetText("No price data yet \226\128\148 scanning...")
     end
-
-    ui.UpdateSellHistory(it)
 
     local unitBuy = ReadMoneyBox(ui.sellBuyout)
     local size    = ui.GetStackSize(it)
@@ -4867,49 +4979,6 @@ function ui.DoSellMarked()
     ui.RefreshMerchantButton()
     if ui.vendList and ui.vendList:IsVisible() then ui.RefreshVendorList() end
     if ui.sellBuilt then ui.RefreshBags() end
-end
-
--- Sell tab History block: the median the SCANS say (with the observed range and
--- how many days back it goes), and what this item has actually SOLD for.
-function ui.UpdateSellHistory(it)
-    if not ui.sellHistScan then return end
-    if not it then
-        ui.sellHistScan:SetText("")
-        ui.sellHistSold:SetText("")
-        return
-    end
-
-    -- Scan side: time-weighted median of daily minimum buyouts, plus the range.
-    local median = A.db.MarketValue(it.itemId)
-    local days, low, high = A.db.PriceSpread(it.itemId)
-    if median and days > 0 then
-        local txt = "Scans: med " .. util.FormatMoney(median, true)
-            .. "  (" .. days .. "d"
-        if low and high and low ~= high then
-            txt = txt .. " " .. util.FormatMoney(low, true)
-                .. "\226\128\147" .. util.FormatMoney(high, true)
-        end
-        ui.sellHistScan:SetText(txt .. ")")
-        ui.sellHistScan:SetTextColor(C.text[1], C.text[2], C.text[3])
-    else
-        ui.sellHistScan:SetText("Scans: no data yet")
-        ui.sellHistScan:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
-    end
-
-    -- Sales side: what the mailbox ledger says this actually sold for.
-    local sMed, sCount, sLast = A.db.SaleHistory(it.name)
-    if sMed and sCount > 0 then
-        local txt = "Sold: " .. sCount .. "x  med "
-            .. util.FormatMoney(sMed, true)
-        if sLast and sLast ~= sMed then
-            txt = txt .. "  last " .. util.FormatMoney(sLast, true)
-        end
-        ui.sellHistSold:SetText(txt)
-        ui.sellHistSold:SetTextColor(0.30, 0.85, 0.30)
-    else
-        ui.sellHistSold:SetText("Sold: none yet")
-        ui.sellHistSold:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
-    end
 end
 
 -- ---- post-scan sell queue ----------------------------------------------
@@ -5451,6 +5520,17 @@ function ui.SelectSubTab(name)
     if name ~= "Sell" then
         ui.HideVendorList()
     end
+    ui.RefreshCurrentTab(true)
+end
+
+-- Repaint whichever tab is showing.
+--
+-- ui.Refresh() only ever touched the scan strip, so resizing the window
+-- recomputed nothing: the lists kept the row count they were last painted with
+-- and the extra height just went blank. Anything that changes how much room the
+-- lists have has to come through here.
+function ui.RefreshCurrentTab(requestAuctions)
+    local name = ui.selectedSubTab
     if name == "Sell" then
         ui.RefreshBags()
         ui.RefreshSell()
@@ -5459,7 +5539,9 @@ function ui.SelectSubTab(name)
     elseif name == "Crafting" then
         ui.RefreshCraft()
     elseif name == "Auctions" then
-        ui.RefreshAuctions(true)
+        -- Only ping the server when actually switching to the tab; a resize
+        -- must not fire an owner-list query.
+        ui.RefreshAuctions(requestAuctions and true or false)
     elseif name == "History" then
         ui.RefreshHistory()
     elseif name == "Scan" then


### PR DESCRIPTION
Four things from the last round of in-game testing.

## Rows stopped appearing as the window grew

Releasing the resize grip called `ui.Refresh()`, which paints the scan strip and nothing else. No list ever recomputed how many rows now fit, so the extra height became blank space — or, in the bag list, more scrolling.

`ui.RefreshCurrentTab()` is split out of `SelectSubTab` and called on release. It takes a `requestAuctions` flag so a resize can repaint the Auctions tab **without** firing an owner-list query at the server on every drag.

## Window scale (Aegis tab)

Resizing and scaling answer different questions. Vanilla frames never reflow, so a bigger window can only ever show *more* rows, never larger ones — scale is the other axis. Steps of 5% between 70% and 150%, with a Reset, remembered per character next to the size.

Deliberately buttons rather than a slider: a slider that rescales the window it sits on moves out from under the cursor mid-drag, and the thumb then tracks to a different value.

## Flat undercut is entered in coins

It's the same gold/silver/copper widget the Sell tab's bid and buyout use. The group already emulated the single box's `GetText`/`SetText`, so `CommitUndercutFlat` and `RefreshSettings` needed no changes — only a `quiet` flag, because committing on every keystroke would repaint the boxes from the stored value while you were still typing in them.

## Sell tab in two columns

Left is *what am I posting* — both sliders stacked, duration under them. Right is *for how much* — the pricing buttons above the two money rows they write into. They used to interleave on shared rows, which meant reading a price and reading a stack size were the same eye movement.

Pricing is **Undercut / Price match** rather than Market / Undercut / Vendor:

- "Market" was the same reference price with no undercut applied — price-match with worse data.
- "Vendor" is a floor, not a strategy. The vendor figure is still shown in that column, and the Vendor list still calls out items worth more to a merchant than to the AH.

`sell.MatchUnit()` is the shared reference both buttons work from, so they can never disagree about who the competition is.

The History block is gone as asked. The scan median, minimum buyout and vendor price still sit on the line under the item name; what things actually sold for lives on the History tab. The posting status line moved to its own row — squeezed onto the duration row it had ~160px before it ran into the price column, which isn't enough for `Item 7 of 23 — Elemental Earth`.

The control block grew 12px, so `MIN_H` went 460 → 472 to keep the smallest window showing exactly the rows it did before (verified: 9 bag rows, 9 listing rows either way).

## Also fixed

A saved scale was only applied when there was **also** a saved size — `RestoreWindowSize` bailed out early — so scaling the window without ever resizing it lost the setting at every login.

## Testing

Syntax checked with `luac5.1 -p`; the simulated 1.12 harness passes. New coverage: the coin triplet's quiet-vs-loud commit, scale clamping/persistence/application, `MatchUnit` vs `UndercutUnit`, the Sell tab's anchor chain, and that releasing the grip repaints the open tab without a server query.

Every new assertion was sabotage-tested — each fix reverted individually to confirm the test actually fails without it. Three first drafts passed under sabotage and were rewritten:

- the keystroke test used a value that normalised to itself, so quiet and loud commits looked identical (now `207c` in the copper box, which a repaint would rewrite to `4s07c`);
- the scale-clamp test read through `WindowScale()`, which clamps on the way out and hid a broken step clamp (now asserts the *stored* value);
- the layout test compared anchor objects that differ either way (now walks the real anchor chain: stacks-under-size, duration-under-both, buttons-above-money-rows).

`SetScale`/`GetScale` were added to the harness's frame mock — without them `ui.ApplyWindowScale` silently no-opped and the scale tests proved nothing.

Not a **restart** release — no new `.lua` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_