### PR TITLE
v1.5.0 — ROADMAP 2a: a search query language on the Buy tab

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.5.3
+## Version: 1.6.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.4.0
+## Version: 1.5.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.5.0
+## Version: 1.5.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.5.2
+## Version: 1.5.3
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.6.0
+## Version: 1.7.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.7.0
+## Version: 1.8.0
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.5.1
+## Version: 1.5.2
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.7.0]
+
+### Added
+- **Filter Builder on the Buy tab** (ROADMAP 2b). A **Builder** view sitting
+  beside **Results** in the same space: fill in a form — Name, Exact, Level
+  range, Class, Subclass, Slot, Quality, Usable, plus Buyout only, Full stacks,
+  Stack size and Tooltip contains — and it writes the query for you, shown live
+  as you go.
+
+  Class gates Subclass gates Slot, the way the auction house's own dropdowns
+  do, and every list is populated from the game's **own localized category
+  names** — the same source the typed query language reads, so there is no
+  second copy to drift.
+
+  **Search** runs it. **To box** copies the query into the search box, **+ OR**
+  appends it as another `;` term, **From box** loads a typed query back into
+  the form. Round-tripping is the feature's contract and is tested: whatever
+  the form builds must parse back to the same search.
+
+  The form edits **one** term. Loading a multi-term query fills in the first
+  and says so explicitly rather than quietly dropping the rest.
+
+### Changed
+- `GetItemInfo` is now read through one shared normaliser (`util.ItemInfo`)
+  that returns **named** fields. Its return list differs between clients —
+  vanilla 1.12 has no `itemLevel`, so every field after the third sits one slot
+  earlier than on later clients — and two separate positional reads had already
+  shipped with bugs from it: the stack-size lookup that made `/stack` misbehave
+  for several releases, and the Sell tab's bag-list headers, which grouped by
+  item *type* on one client and *subtype* on the other. No caller indexes
+  `GetItemInfo` by position any more.
+
+---
+
 ## [1.6.0]
 
 ### Added
@@ -759,6 +793,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.7.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.6.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.3]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.5.2]
+
+### Fixed
+- **`stack` showed every stack size, not just full ones.** v1.5.1 made the
+  filter fail *open* when an item's maximum stack size was unknown, which
+  turned out to mean "always" for items your client hasn't cached — so it let
+  everything through instead of everything being hidden. Both failure modes
+  looked equally broken.
+
+  Max stack size has exactly one source on 1.12 — `GetItemInfo`, which only
+  answers for items already in the client's local cache, i.e. not the ones
+  you're shopping for. **Aegis now remembers every stack size it learns**
+  (account-wide, alongside vendor prices — it's a property of the item, not
+  the realm), so the filter fills in as you browse and play. Anything still
+  unknown is excluded *and counted*, with the status line saying so:
+  `No full stacks • 12 skipped (stack size unknown — search again)`.
+
+- **`weapon/dagger` returned thrown weapons with "Dagger" in the name.** The
+  game's category names are plural and often qualified — "Daggers",
+  "One-Handed Swords" — so the singular never matched, fell through to a name
+  search, and dragged in anything called "…Dagger". Categories now match on an
+  exact name, then a unique prefix, then a unique substring.
+
+  Deliberately *unique*: `weapon/sword` matches both One-Handed and Two-Handed
+  Swords, so it stays a name search rather than silently picking one half and
+  returning a confidently wrong page. Naming one exactly still works.
+
+---
+
 ## [1.5.1]
 
 ### Added
@@ -684,6 +713,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.5.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.4.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.6.0]
+
+### Added
+- **`stack <n>` — search for an exact stack size.** `silk cloth/stack 20`,
+  `silk cloth/stack 8`. It compares each listing's own count and needs no item
+  data whatsoever, so it works on the first search, for any item, however cold
+  the client's item cache is. Three spellings all work: `stack 20`,
+  `stack/20`, `stack20` — the spaced one matters because search terms split on
+  `/`, so `stack 20` arrives as a single token.
+
+### Changed
+- **Bare `stack` no longer dead-ends when an item's maximum can't be read.**
+  It still means "full stacks" and still prefers the real maximum, but when
+  the client can't supply one it now falls back to the largest stack of that
+  item on the page — which needs no item data at all — and says
+  `biggest on this page` in the status line so the weaker promise is never
+  passed off as the stronger one.
+
+  This is a pragmatic answer to `GetItemInfo` being unreliable here in ways
+  three attempts haven't fully pinned down. `stack <n>` is the form to use
+  when you want a guarantee.
+
+---
+
 ## [1.5.3]
 
 ### Fixed
@@ -735,6 +759,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.6.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.3]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,59 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.5.1]
+
+### Added
+- **Search results are coloured by item quality**, matching each item's
+  tooltip — a rare reads blue, an epic purple. Colours come from FrameXML's own
+  `ITEM_QUALITY_COLORS`, so they match the rest of the game exactly rather than
+  being re-guessed. Applies to the Buy tab and the Crafting tab's reagent
+  results, which share a row painter.
+
+### Fixed
+- **`armor/leather` and other category searches returned nothing.** Class,
+  subclass and slot keywords were never implemented — they fell through to
+  being name text, so `armor/leather` searched for an item literally *called*
+  "armor leather". They now resolve against the auction house's **own
+  localized category names** (`GetAuctionItemClasses` /
+  `GetAuctionItemSubClasses` / `GetAuctionInvTypes`), so `armor/leather`,
+  `container/bag` and `armor/plate/chest` all work — in any client language.
+
+  Subclasses resolve *within* their class, because names repeat: "Leather"
+  exists under both Armor and Trade Goods, and "Mail" exists only under Armor.
+  `trade goods/mail` correctly leaves "mail" as name text instead of silently
+  searching a category you never asked for.
+
+- **`container/bag/tooltip/8` returned nothing** — same root cause. Now that
+  the categories resolve, both halves of that pair work as documented:
+  `container/bag/tooltip/8` filters tooltips for "8", `container/bag/8`
+  searches names for "8".
+
+- **`mageweave/stack` returned an empty page.** The fully-stacked filter needs
+  each item's max stack size from `GetItemInfo`, which only answers for items
+  already in the client's cache — and it was failing *closed*, so on a cold
+  cache every row was hidden, indistinguishable from "no full stacks exist".
+  It now fails open: a few partial stacks may show until the cache warms.
+
+- **Tooltip searches matched the wrong listings, or nothing at all.**
+  `GameTooltipTemplate` reuses its text lines, so text from a previous, longer
+  tooltip is still sitting in the higher-numbered ones. Reading "until a line
+  comes back empty" walked off the end of the current tooltip into that stale
+  text. Now bounded by `NumLines()`, and built lazily with the same
+  owner-then-clear-then-set sequence the Sell tab's bind-status scanner has
+  always used.
+
+- **The "you can't use this" warning never appeared.** `GetAuctionItemInfo`
+  returns `canUse` as `1`-or-`nil`, so `nil` *is* the cannot-use answer — but
+  the check treated it as "unknown, assume fine", making the warning
+  unreachable. It now fires correctly, and shows as a red icon tint (the name
+  colour having been taken over by item quality).
+
+- Quality keywords now also accept the client's own localized names via
+  `ITEM_QUALITY<n>_DESC`, with the English words kept as a fallback.
+
+---
+
 ## [1.5.0]
 
 ### Added
@@ -631,6 +684,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.5.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.4.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.3.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ printed in the window title bar — quote it in bug reports.
   for several releases, and the Sell tab's bag-list headers, which grouped by
   item *type* on one client and *subtype* on the other. No caller indexes
   `GetItemInfo` by position any more.
+- The Courier detection fallback no longer guesses at the companion addon's
+  global. Confirmed against Aegis: Courier's own source, it is `AegisCourier`;
+  `Aegis_Courier` is the folder and `.toc` name and is never a global, so it is
+  no longer accepted. Only affects a Courier that loads without calling
+  `ClaimMailScanning` — the explicit handshake was and remains the contract.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.5.3]
+
+### Fixed
+- **`stack` said "stack size unknown" even for items sitting in your own bags.**
+  A stack of 20 Silk Cloth is definitely in the client's item cache, so the
+  cache was never the problem — the code was reading the wrong value out of
+  `GetItemInfo`.
+
+  Its return list is not the same on every client: vanilla 1.12 returns nine
+  values, while later clients insert `itemLevel` at position 4 and shift
+  everything after it down a slot. Counting slots therefore reads the stack
+  count on one client and the equip slot on the other — which is empty for a
+  trade good (hence "unknown" for every cloth, ore and herb) and a string like
+  `INVTYPE_CHEST` for gear, where it would have thrown outright.
+
+  The stack count is the **last number** in that list under both layouts —
+  everything after it is a string — so that is what Aegis looks for now,
+  instead of counting positions. The test suite runs these checks under *both*
+  return layouts, so a fix that only works on one can't pass.
+
+---
+
 ## [1.5.2]
 
 ### Fixed
@@ -713,6 +735,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.5.3]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,52 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.8.0]
+
+### Added
+- **Category tree on the Buy tab** (ROADMAP 2e). The left column now opens as
+  a Blizzard-style **category tree**: click **Weapons > Two-Handed Swords** or
+  **Armor > Leather > Chest** and it searches — no typing, no syntax. Every
+  list in it comes from the client's own localized category names, the same
+  source the query language and the Builder's dropdowns read.
+
+  A tree pick **composes** with whatever is already in the search box rather
+  than replacing it: pick a category with `quality/rare/stack 20` typed and
+  you get rare 20-stacks *of that category*. Extra `;` terms ride along
+  untouched. That composition is the feature's contract and is tested.
+
+  The **Advanced** button swaps the tree back to the shopping-list sidebar
+  (lists + recent searches); **Categories** brings the tree back. The choice
+  sticks per character.
+
+### Fixed
+- **Exact match with an empty Name matched nothing at all.** `""` is truthy
+  in Lua, so a nameless term's exact filter compared every listing against an
+  empty string and rejected the entire page — an Exact checkbox ticked
+  without a name could never return a single result, whatever else was set.
+  Exact now only engages when there is a name to be exact *about*. (This was
+  the likely shape of the reported "Silk Cloth + stack 10 + Exact finds
+  nothing": the named form of that search passes, and passes a test now.)
+- **A page emptied by filters no longer reads as "No auctions found."** It
+  now says `0 match(es) (of N) • filters removed this page's rows — try the
+  next page`, because an unexplained empty page is indistinguishable from a
+  broken filter — exactly how `/stack` got reported in 1.5.x, and how this
+  one got reported too.
+- **The dropdown menus in the Filter Builder were see-through.** Their
+  texture paths were written with single backslashes, which Lua silently
+  swallows (`"\T"` is not an escape), so the client was asked for
+  `InterfaceTooltips...` — a texture that does not exist — and drew no
+  background and no hover highlight at all. Paths doubled, popup made fully
+  opaque, and lifted to its own strata so nothing in the window can paint
+  over it. Three tests now pin those strings byte-for-byte.
+- **Long recent searches wrecked the sidebar.** A long query wrapped onto a
+  second line and painted across the row below it. Sidebar rows now clip
+  with an ellipsis and show the **full query in a tooltip** on hover.
+- **The Builder view no longer shows the results status line or pager.**
+  "7 match(es) • unit low to high" used to print straight through the form's
+  heading, and the `<` `>` buttons still paged (and queried the server) for
+  a list you couldn't see.
+
 ## [1.7.0]
 
 ### Added
@@ -798,6 +844,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.8.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.7.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.6.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.5.3]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,60 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.5.0]
+
+### Added
+- **A search query language on the Buy tab** (ROADMAP 2a). Typing a plain item
+  name still does exactly what it always did — a bare word with no keyword is
+  just name text, same as ever. The same box now also understands:
+
+  | Query | Effect |
+  |---|---|
+  | `linen cloth/exact` | only *Linen Cloth*, not *Bolt of Linen Cloth* |
+  | `belt/quality3`, `belt/quality/rare` | server-side quality filter |
+  | `sword/level20-30`, `sword/level/25` | server-side level range |
+  | `belt/usable` | server-side "usable by me" flag |
+  | `runecloth/buyout` | exclude bid-only auctions |
+  | `mageweave/stack` | fully-stacked listings only |
+  | `container/bag/tooltip/8` | name *container bag*, tooltip contains *8* |
+  | `linen;wool;silk` | three searches browsed as one list |
+
+  The grammar is aux's (settled in ROADMAP.md) — this is an original
+  implementation of that shape, not ported code. Filters split into the parts
+  the 1.12 server can do (one `QueryAuctionItems` per term) and the parts it
+  can't (applied client-side as each page loads). An unrecognised token can
+  never break a query: it falls back to being literal name text.
+
+  Semicolon terms browse as **one** list — page past the end of one and it
+  rolls into the next, rather than leaving you to notice and re-run.
+
+- **Right-click a bag item on the Buy tab to search for it.** The Sell tab's
+  existing right-click-to-slot is untouched; each only fires on its own tab.
+- **Shift-click any item to search for it** — a bag slot, a chat link, a
+  tooltip. Works through `HandleModifiedItemClick`, the single 1.12 global
+  every shift-click funnels through.
+- **Tab-completion in the search box**, from every item name Aegis has learned
+  (scans, searches, browsing) plus your recent searches. Press Tab again to
+  cycle through the matches.
+
+### Changed
+- The Buy tab's result count now reads `N match(es) (of M)` when a query filter
+  is narrowing the page, so the bigger Blizzard-side number can't be mistaken
+  for "how many I can buy". The pager names the current term (`Term 1/3`) only
+  when a query actually has more than one — a single-term search looks exactly
+  as it always has.
+
+### Fixed
+- Removed a duplicate price-database write on the browse path. `core/buy.lua`
+  folded every browsed listing into the price DB, but `core/scan.lua`'s
+  `RecordVisiblePage` already does that for *every* result page anyone looks
+  at — from the same event, with identical values. Surfaced by a sabotage test
+  that fed the DB from filtered rows instead of raw ones and changed nothing
+  observable. Behaviour is unchanged (and still verified): a filtered search
+  narrows what is **displayed**, never what is **learned**.
+
+---
+
 ## [1.4.0]
 
 ### Changed
@@ -577,6 +631,7 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+[1.5.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.4.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.3.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.2.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.5.0)
+# Aegis: Exchange (v1.5.1)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -67,15 +67,25 @@ changes. But the same box now takes a query language when you want one:
 |---|---|
 | `linen cloth` | exactly what it always did |
 | `linen cloth/exact` | only *Linen Cloth*, not *Bolt of Linen Cloth* |
+| `armor/leather` | the whole Leather Armor category |
+| `armor/plate/chest` | plate chest pieces |
 | `belt/quality3` or `belt/quality/rare` | rare-quality belts |
 | `sword/level20-30` | swords for levels 20–30 |
 | `runecloth/buyout` | skip bid-only auctions |
 | `mageweave/stack` | full stacks only |
-| `container/bag/tooltip/8` | *bag* items whose tooltip mentions **8** |
+| `container/bag/tooltip/8` | bags whose tooltip mentions **8** |
 | `linen;wool;silk` | all three, browsed as one list |
+
+**Categories are the game's own names** — whatever the auction house's own
+dropdowns say, in your own language. Class first, then subclass, then slot:
+`armor/leather` works, `leather/armor` treats "leather" as a name.
 
 Terms combine with `/`, and `;` runs several searches back to back — page past
 the end of one and it rolls straight into the next.
+
+Result names are **coloured by item quality**, the way their tooltips are, so
+a rare reads blue and an epic purple at a glance. An item you can't use gets a
+red-tinted icon.
 
 **Shortcuts while the Buy tab is open:** **right-click** any bag item to search
 for it, or **shift-click** any item *anywhere* — bags, a chat link, a tooltip —
@@ -276,7 +286,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.5.0`) — quote it.
+1. Check the **version** in the window's title bar (`v1.5.1`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.6.0)
+# Aegis: Exchange (v1.7.0)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -101,6 +101,12 @@ the end of one and it rolls straight into the next.
 Result names are **coloured by item quality**, the way their tooltips are, so
 a rare reads blue and an epic purple at a glance. An item you can't use gets a
 red-tinted icon.
+
+**Don't want to learn the syntax?** Hit **Builder** on the Buy tab and fill in
+a form instead — name, level range, class, subclass, slot, quality, and the
+extra filters — with the query it builds shown live underneath. **Search** runs
+it, **To box** copies it out, **+ OR** appends it to what's already there, and
+**From box** loads a typed query back into the form so you can adjust it.
 
 **Shortcuts while the Buy tab is open:** **right-click** any bag item to search
 for it, or **shift-click** any item *anywhere* — bags, a chat link, a tooltip —
@@ -301,7 +307,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.6.0`) — quote it.
+1. Check the **version** in the window's title bar (`v1.7.0`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.5.1)
+# Aegis: Exchange (v1.5.2)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -78,7 +78,15 @@ changes. But the same box now takes a query language when you want one:
 
 **Categories are the game's own names** — whatever the auction house's own
 dropdowns say, in your own language. Class first, then subclass, then slot:
-`armor/leather` works, `leather/armor` treats "leather" as a name.
+`armor/leather` works, `leather/armor` treats "leather" as a name. You don't
+have to match them exactly — `weapon/dagger` finds the "Daggers" category —
+but a word matching *several* categories (`weapon/sword` hits both One-Handed
+and Two-Handed Swords) is left as a name search rather than guessing.
+
+`stack` needs to know each item's maximum stack size, which vanilla only
+reports for items your client has already seen. Aegis remembers every one it
+learns, so the filter gets more complete as you play; anything it can't size
+yet is skipped and counted in the status line rather than silently dropped.
 
 Terms combine with `/`, and `;` runs several searches back to back — page past
 the end of one and it rolls straight into the next.
@@ -286,7 +294,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.5.1`) — quote it.
+1. Check the **version** in the window's title bar (`v1.5.2`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.5.3)
+# Aegis: Exchange (v1.6.0)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -72,7 +72,8 @@ changes. But the same box now takes a query language when you want one:
 | `belt/quality3` or `belt/quality/rare` | rare-quality belts |
 | `sword/level20-30` | swords for levels 20–30 |
 | `runecloth/buyout` | skip bid-only auctions |
-| `mageweave/stack` | full stacks only |
+| `mageweave/stack 20` | stacks of exactly 20 |
+| `mageweave/stack` | the biggest stacks |
 | `container/bag/tooltip/8` | bags whose tooltip mentions **8** |
 | `linen;wool;silk` | all three, browsed as one list |
 
@@ -83,10 +84,16 @@ have to match them exactly — `weapon/dagger` finds the "Daggers" category —
 but a word matching *several* categories (`weapon/sword` hits both One-Handed
 and Two-Handed Swords) is left as a name search rather than guessing.
 
-`stack` needs to know each item's maximum stack size, which vanilla only
-reports for items your client has already seen. Aegis remembers every one it
-learns, so the filter gets more complete as you play; anything it can't size
-yet is skipped and counted in the status line rather than silently dropped.
+**`stack 20` is the reliable form** — it just compares each listing's own
+count, so it needs no item data and works on the first search for any item.
+`stack 8`, `stack 1`, whatever you want. All three spellings work:
+`stack 20`, `stack/20`, `stack20`.
+
+Bare **`stack`** means "full stacks", which needs the item's *maximum* size —
+and vanilla only reports that for items your client has already cached. Aegis
+remembers every maximum it learns, and when it still doesn't know one it falls
+back to the biggest stack of that item on the page, saying so in the status
+line. If you want a guarantee rather than a best guess, give the number.
 
 Terms combine with `/`, and `;` runs several searches back to back — page past
 the end of one and it rolls straight into the next.
@@ -294,7 +301,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.5.3`) — quote it.
+1. Check the **version** in the window's title bar (`v1.6.0`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.4.0)
+# Aegis: Exchange (v1.5.0)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -59,6 +59,28 @@ Search the AH, sort by unit price, stack price, or % of market value, and buy or
 bid straight from the results. Colour-coded so bargains jump out: **green is
 under market, red is over.** Keep **shopping lists** of the things you always
 need (all your tailoring mats, say) and search the whole list in one click.
+
+**Typing a name still just searches for that name** — nothing you already do
+changes. But the same box now takes a query language when you want one:
+
+| Type this | Get that |
+|---|---|
+| `linen cloth` | exactly what it always did |
+| `linen cloth/exact` | only *Linen Cloth*, not *Bolt of Linen Cloth* |
+| `belt/quality3` or `belt/quality/rare` | rare-quality belts |
+| `sword/level20-30` | swords for levels 20–30 |
+| `runecloth/buyout` | skip bid-only auctions |
+| `mageweave/stack` | full stacks only |
+| `container/bag/tooltip/8` | *bag* items whose tooltip mentions **8** |
+| `linen;wool;silk` | all three, browsed as one list |
+
+Terms combine with `/`, and `;` runs several searches back to back — page past
+the end of one and it rolls straight into the next.
+
+**Shortcuts while the Buy tab is open:** **right-click** any bag item to search
+for it, or **shift-click** any item *anywhere* — bags, a chat link, a tooltip —
+to drop its name in the box and go. **Tab** completes what you've typed from
+every item Aegis has ever seen, pressing it again to cycle through the matches.
 
 ### 💰 Sell — price it right the first time
 Drop an item in and Aegis scans the AH for *just that item*, shows you every
@@ -254,7 +276,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.4.0`) — quote it.
+1. Check the **version** in the window's title bar (`v1.5.0`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.7.0)
+# Aegis: Exchange (v1.8.0)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -102,11 +102,19 @@ Result names are **coloured by item quality**, the way their tooltips are, so
 a rare reads blue and an epic purple at a glance. An item you can't use gets a
 red-tinted icon.
 
-**Don't want to learn the syntax?** Hit **Builder** on the Buy tab and fill in
-a form instead — name, level range, class, subclass, slot, quality, and the
-extra filters — with the query it builds shown live underneath. **Search** runs
-it, **To box** copies it out, **+ OR** appends it to what's already there, and
-**From box** loads a typed query back into the form so you can adjust it.
+**Don't want to learn the syntax?** Two ways around it. The left side of the
+Buy tab is a **category tree**, just like the stock auction house: click
+**Weapons > Two-Handed Swords** or **Armor > Leather > Chest** and it
+searches, no typing needed — and anything already in the search box (a name,
+`quality/rare`, `stack 20`…) stays applied on top of the category you picked.
+The **Advanced** button swaps the tree back to your shopping lists and recent
+searches.
+
+Or hit **Builder** and fill in a form instead — name, level range, class,
+subclass, slot, quality, and the extra filters — with the query it builds
+shown live underneath. **Search** runs it, **To box** copies it out, **+ OR**
+appends it to what's already there, and **From box** loads a typed query back
+into the form so you can adjust it.
 
 **Shortcuts while the Buy tab is open:** **right-click** any bag item to search
 for it, or **shift-click** any item *anywhere* — bags, a chat link, a tooltip —
@@ -307,7 +315,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.7.0`) — quote it.
+1. Check the **version** in the window's title bar (`v1.8.0`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.5.2)
+# Aegis: Exchange (v1.5.3)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -294,7 +294,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.5.2`) — quote it.
+1. Check the **version** in the window's title bar (`v1.5.3`) — quote it.
 2. `/aex debug` turns on a scanner trace if a scan is misbehaving.
 3. Tell us on **[Discord](https://discord.gg/hsgPTNkSX)** or open an
    [issue](https://github.com/Torchlite-bit/Aegis_Exchange/issues). Screenshots

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,10 +91,33 @@ is the single most likely way the integration could corrupt someone's history.
 survives Courier being renamed. There *is* a global-name fallback for a Courier
 that loads without claiming, but it is a safety net, not the contract.
 
-> ⚠️ **Open, for the Courier session to close:** that fallback currently guesses
-> at `AegisCourier` / `Aegis_Courier`. Once Courier settles its real addon
-> global, trim `COURIER_GLOBALS` in `core/db.lua` to the true name. Harmless
-> either way as long as Courier calls `ClaimMailScanning`.
+**Closed (v1.7.0):** the fallback used to guess at `AegisCourier` /
+`Aegis_Courier`. Courier's `core/init.lua` declares **`AegisCourier`**, and
+`Aegis_Courier` is only the folder / `.toc` name — never a global — so the list
+is now the single confirmed name. A test pins it: sniffing the folder name must
+NOT stand Aegis's scanner down.
+
+> 🚨 **Open — the two repos disagree about `RecordExternalTxn`'s shape, and it
+> fails SILENTLY.** Aegis takes **one table** (above). Courier's
+> `core/bridge.lua` calls it with **four positional args**:
+> ```lua
+> local ok = pcall(AegisExchange.RecordExternalTxn, kind, item, amount, itemId)
+> ```
+> Aegis then sees `txn = "sale"`, hits `type(txn) ~= "table"` and **returns**
+> `false, "payload must be a table"` — it does not error, so `pcall` reports
+> success, `bridge.Push` returns true, and every push is dropped with no
+> warning on either side. Both repos claim `INTEGRATION_VERSION = 1`, so the
+> version guard cannot catch it. Courier also never sends `key`, so
+> `MailTxnKey` dedup never engages.
+>
+> Not fixed here, because which side moves is a cross-repo call:
+> - **Change Courier** (`bridge.Push` builds the table, passes `key`) — keeps
+>   Aegis's published contract, and Courier is the newer, unshipped side.
+> - **Change Aegis** to also accept the positional form — wider blast radius
+>   and two shapes to keep working forever. Not recommended.
+>
+> Either way `bridge.Push` should check the RETURNED value, not just `pcall`'s
+> ok flag, or a rejected payload stays invisible.
 
 Full design (data-flow direction, standalone requirement) below in **Phase 1**.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,32 +59,54 @@ if AegisExchange and AegisExchange.INTEGRATION_VERSION then
     --    Call from Courier's ADDON_LOADED.
     AegisExchange.ClaimMailScanning("Aegis: Courier")
 
-    -- 2. Build the dedup key for an auction mail THROUGH THIS HELPER.
-    local key = AegisExchange.MailTxnKey(subject, money, daysLeft)
-
-    -- 3. Push the matched transaction.
+    -- 2. Push the matched transaction. ONE TABLE -- see the warning below.
     local ok, why = AegisExchange.RecordExternalTxn({
         kind   = "sale",        -- or "buy"
         item   = "Silk Cloth",
         amount = netProceeds,   -- copper, AFTER the 5% cut (what actually
                                 -- arrived in the mail)
         itemId = 4306,          -- optional
-        key    = key,           -- optional; repeats are ignored
+        -- key = ...            -- OPTIONAL, and usually WRONG. See below.
     })
 end
 ```
+
+> 🚨 **It takes ONE TABLE, and calling it positionally fails SILENTLY.**
+> `RecordExternalTxn` reports a bad payload by **returning** `false, reason` —
+> it does not raise — so a caller that wraps it in `pcall` and checks only the
+> ok flag sees success while every entry is dropped. Courier shipped exactly
+> that bug and it survived from its first release to v1.0.2, because its test
+> double had the same wrong signature and agreed with it. **Check the returned
+> value, not just that the call didn't error.**
 
 `RecordExternalTxn` returns `true`, or `false` plus a short reason
 (`"duplicate"`, `"kind must be 'sale' or 'buy'"`, …) so Courier can surface
 failures rather than miscounting silently. `INTEGRATION_VERSION` is currently
 **1**; it bumps whenever a signature or field meaning changes.
 
-**Why `MailTxnKey` is exposed rather than left internal.** A user who ran Aegis
-alone already has auction mails in the ledger under *Aegis's* keys. If Courier
-invented its own key scheme it would re-report those mails and double-count
-every one of them on the day Courier is installed. Generating keys through the
-shared helper makes the handover seamless. This matters more than it looks — it
-is the single most likely way the integration could corrupt someone's history.
+**Why `MailTxnKey` is exposed — and why Courier does NOT use it.** It was put
+here for a caller that books mail on **arrival**, as Aegis's own scanner does:
+such a caller sees the same mail on every inbox refresh and needs a fingerprint
+to avoid re-reporting it, and sharing Aegis's own key scheme means a user who
+ran Aegis alone doesn't get their existing entries double-counted on the day
+the companion is installed.
+
+**That advice is wrong for a caller that books on collection, and Courier is
+one.** `MailTxnKey` buckets `subject | money | arrival-hour`, so **two identical
+stacks sold at the same price within the same hour produce the same key** — the
+second is rejected as `"duplicate"` and lost. A collision *under*-counts, and a
+missing sale is invisible in a way a doubled one is not. Courier books when a
+mail is emptied (`take.Confirm`), which is self-limiting: an emptied mail has
+nothing left to book, so it sends no key at all.
+
+The residual overlap is accepted on both sides and written down in Courier's
+`bridge.lua`: mail Aegis already booked on arrival that is **still uncollected**
+when Courier is installed gets counted twice. That is a one-time, bounded
+handover window, not an ongoing defect.
+
+So: keep `MailTxnKey` exposed — Aegis's own standalone scanner uses it, and an
+arrival-time companion would want it — but it is **not** part of the recommended
+Courier path.
 
 **Mail ownership** is an explicit handshake (`ClaimMailScanning` /
 `ReleaseMailScanning`) rather than Aegis sniffing for a global, because explicit
@@ -97,27 +119,25 @@ that loads without claiming, but it is a safety net, not the contract.
 is now the single confirmed name. A test pins it: sniffing the folder name must
 NOT stand Aegis's scanner down.
 
-> 🚨 **Open — the two repos disagree about `RecordExternalTxn`'s shape, and it
-> fails SILENTLY.** Aegis takes **one table** (above). Courier's
-> `core/bridge.lua` calls it with **four positional args**:
-> ```lua
-> local ok = pcall(AegisExchange.RecordExternalTxn, kind, item, amount, itemId)
-> ```
-> Aegis then sees `txn = "sale"`, hits `type(txn) ~= "table"` and **returns**
-> `false, "payload must be a table"` — it does not error, so `pcall` reports
-> success, `bridge.Push` returns true, and every push is dropped with no
-> warning on either side. Both repos claim `INTEGRATION_VERSION = 1`, so the
-> version guard cannot catch it. Courier also never sends `key`, so
-> `MailTxnKey` dedup never engages.
->
-> Not fixed here, because which side moves is a cross-repo call:
-> - **Change Courier** (`bridge.Push` builds the table, passes `key`) — keeps
->   Aegis's published contract, and Courier is the newer, unshipped side.
-> - **Change Aegis** to also accept the positional form — wider blast radius
->   and two shapes to keep working forever. Not recommended.
->
-> Either way `bridge.Push` should check the RETURNED value, not just `pcall`'s
-> ok flag, or a rejected payload stays invisible.
+**The seam was dead from Courier's first release until its v1.0.2.** Courier
+called `RecordExternalTxn` with four positional arguments instead of the table.
+Aegis saw `txn = "sale"`, failed its own type check and **returned** false —
+without erroring — so Courier's `pcall` reported success and every push was
+dropped with no warning on either side. Both repos claimed
+`INTEGRATION_VERSION = 1`, so the version guard could not catch it.
+
+**Fixed entirely on Courier's side** (its PR #7); nothing in Aegis changed and
+`INTEGRATION_VERSION` stays at **1** — the table shape was always the published
+contract, and Aegis had no wrong caller to accommodate. Courier now also reads
+the returned value rather than just `pcall`'s ok flag, which is the part that
+kept the bug invisible.
+
+Worth remembering when the next companion is written: **this API's failure mode
+is a silent false success.** Returning `false, reason` is friendlier than
+erroring right up until a caller ignores the return. If a third integration
+ever appears, consider having `RecordExternalTxn` print a one-time developer
+warning when it is handed a string where a table belongs — the positional call
+is unmistakable, and it would turn this exact mistake into something visible.
 
 Full design (data-flow direction, standalone requirement) below in **Phase 1**.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -299,10 +299,11 @@ Search Results / Saved Searches / Filter Builder split, mapped onto Aegis's
 current layout rather than replacing it:
 
 - The existing **Shopping Lists sidebar** (`ui/frame.lua` `BuildBuyTab`,
-  named multi-item lists searched sequentially) stays exactly as-is — aux
-  doesn't have an equivalent concept, and it's a genuinely different use
-  case from a single saved query. It is not being merged into Saved
-  Searches.
+  named multi-item lists searched sequentially) stays — aux doesn't have an
+  equivalent concept, and it's a genuinely different use case from a single
+  saved query. It is not being merged into Saved Searches. (Since 2e it
+  lives behind the left column's **Advanced** toggle, sharing the space
+  with the category tree; nothing about how it works changed.)
 - The right-hand content area gains a row of switchable views — **Search
   Results** (today's results table, now also accepting typed query syntax),
   **Saved Searches**, and **Filter Builder** — reusing the sidebar's screen
@@ -434,13 +435,39 @@ prefix-notation combination, plus stat-suffix matching (the
 `+3 stamina/+3 agility` wristband-suffix case) and any remaining aux
 primitives worth carrying over.
 
-### 3e — Blizzard-style Category Navigation Tree
-Decided. Integrate default Blizzard-style category browsing directly into the search interface
-- Displays a collapsible category tree on the left side of the search view (e.g., Weapons > Two-Handed Maces or Armor > Leather).
-- Allows users to easily browse specific item slots or types visually without having to rely strictly on typing name search queries or remembering syntax.
- - Category filters feed cleanly into the underlying search engine alongside post-filter rules.
+### 2e — Blizzard-style Category Navigation Tree — ✅ **DONE** (v1.8.0)
+(Numbered 3e when it was written; it shipped inside Phase 2, out of order,
+because the user asked for it ahead of 2c/2d.)
 
-### 3f — Session Purchase & Crafting Material Tracker
+The Buy tab's left column now opens as a collapsible **class > subclass >
+slot** tree (Weapons > Two-Handed Swords; Armor > Leather > Chest). Clicking
+a node searches it immediately. A **Categories / Advanced** toggle at the top
+swaps between the tree and the original Shopping Lists sidebar (lists +
+recent searches); the choice persists per character, tree by default.
+
+**Settled while building it:**
+
+- **Tree picks COMPOSE with the query box.** A click parses the box's first
+  term, swaps only class/subclass/slot, regenerates and searches — so typed
+  name/quality/stack/tooltip filters stay applied on top of the picked
+  category, and extra `;` terms are regenerated untouched (TermToQuery
+  round-trips by value, so this loses nothing). This is the "feed cleanly
+  into the underlying search engine" requirement, and it is pinned by a
+  sabotage-verified test.
+- **The tree reads `buy.ClassOptions` / `SubclassOptions` / `SlotOptions`** —
+  the exact three calls the Builder's dropdowns use. Still no second category
+  list anywhere.
+- **The paint paths are mode-guarded**, not just the widgets hidden: every
+  search refreshes the recent list, and an unguarded sidebar repaint would
+  `Show()` its rows straight over the tree. A test drives a search from the
+  tree and asserts the sidebar stays down.
+- **"Advanced replaces the tree"** is interpreted as: Advanced shows the
+  Shopping Lists sidebar (which contains the saved/recent searches), while
+  the Results/Builder switch on the right stays available in BOTH modes.
+  When 2c ships a dedicated Saved Searches view it slots into the existing
+  right-hand view switcher, not the left column.
+
+### 2f — Session Purchase & Crafting Material Tracker
 
 **Decided.** Add a real-time purchasing and material tracking widget to the AH interface to streamline bulk crafting and recipe purchases.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -285,19 +285,34 @@ typing an item name searches by name exactly as before. Shipped in the same box:
   right-click-to-slot untouched — each fires only on its own tab), shift-click
   any item anywhere to search it, Tab-completion from every learned item name.
 
-**Two notes for 2b/2d:**
+**Categories** (`armor/leather`, `container/bag`, `armor/plate/chest`) landed
+in v1.5.1 after the first cut shipped without them and immediately read as
+broken — they fell through to name text, so `armor/leather` searched for an
+item *called* "armor leather". `buy.Categories()` caches the class → subclass
+map from the client's own localized names and `SlotsFor()` does slots; **2b's
+Filter Builder should populate its dropdowns from those same two, not build a
+parallel map.** Subclasses are keyed BY CLASS deliberately: names repeat
+("Leather" under both Armor and Trade Goods) and "Mail" exists only under
+Armor, so a flat map silently searches a category the user never asked for.
 
-1. `class`/`subclass`/`slot` keywords are **not** in this slice. They need
-   index maps built from `GetAuctionItemClasses` / `GetAuctionItemSubClasses` /
-   inventory-type constants; the Filter Builder (2b) needs those same maps for
-   its dropdowns, so build them once there and let the parser share them.
-2. This slice's post-filters all apply together — an implicit AND. Prefix
-   `and`/`or`/`not` combination is 2d's job, and `CompileTerm`'s single
-   `filter` closure is the seam it should compose into.
+**One note for 2d:** this slice's post-filters all apply together — an implicit
+AND. Prefix `and`/`or`/`not` combination is 2d's job, and `CompileTerm`'s
+single `filter` closure is the seam it should compose into.
 
-**Watch out for** (found the hard way): `local a, b = cond and f()` silently
-drops `f`'s second return whenever `and` truncates to one value. Cost a
-half-parsed level range until a test caught it.
+**Watch out for** (all found the hard way):
+
+- `local a, b = cond and f()` silently drops `f`'s second return whenever `and`
+  truncates to one value. Cost a half-parsed level range until a test caught it.
+- **`GameTooltipTemplate` reuses its `TextLeftN` FontStrings.** Reading them
+  "until one comes back empty" walks off the end of the current tooltip into
+  whatever longer tooltip was shown before. Bound the loop with `NumLines()`,
+  and copy `sell.lua`'s owner → clear → set sequence rather than inventing one.
+- **A filter that needs `GetItemInfo` must fail OPEN.** It only answers for
+  cached items, so failing closed empties the entire page on a cold cache and
+  looks exactly like "no matches exist".
+- **`canUse` from `GetAuctionItemInfo` is `1`-or-`nil`** — `nil` means cannot
+  use, not "unknown". Treating nil as unknown made a warning unreachable for
+  the entire life of the Buy tab.
 
 **Also fixed on the way:** `core/buy.lua` was folding every browsed listing
 into the price DB, which `core/scan.lua`'s `RecordVisiblePage` already does for

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -265,27 +265,44 @@ current layout rather than replacing it:
   **Saved Searches**, and **Filter Builder** — reusing the sidebar's screen
   real estate rather than adding a fourth top-level sub-tab.
 
-### 2a — Parser, compiler, core primitives (same search box)
-Nothing about today's casual usage changes: typing an item name still just
-searches by name. Additionally supported in the same box:
-- Blizzard-query / post-filter split — one Blizzard query per search term
-  (drives page count via the existing 9-arg `QueryAuctionItems`), unlimited
-  post-filters applied client-side as each page loads (`buy.ReadPage`
-  already reads one page at a time — post-filters slot into that loop).
-- `exact` modifier, tailored as tightly as the Blizzard query allows
-  (level range, class/subclass/slot, quality) — cannot combine with a
-  manual filter on those same fields.
-- Tooltip-substring search, with the leading-term-vs-tooltip disambiguation
-  aux uses (name search before any category term, tooltip search after; the
-  `container/bag/tooltip/8` vs `container/bag/8` case is the concrete test).
-- The two filters explicitly requested: buyout-only (exclude bid-only
-  auctions), and fully-stacked-only (stack size == max for that item).
-- Quick wins that only need the existing box, done here while it's already
-  being touched: 
-   - Right-click an item in your bags while on the Buy tab to instantly initiate a search for that item.
-   - Right-click an item in your bags while on the Sell tab to automatically place it directly into the sell slot for auction creation.
-   - Dragging an inventory item onto the search box or right-clicking an item link in chat.
-   - Tab-autocompletion in the search bar.
+### 2a — Parser, compiler, core primitives — ✅ **DONE** (v1.5.0)
+Casual usage is untouched: a bare word with no keyword is just name text, so
+typing an item name searches by name exactly as before. Shipped in the same box:
+
+- **Blizzard-query / post-filter split.** `buy.CompileTerm` returns `{ blizz,
+  filter }` — one 9-arg `QueryAuctionItems` per term, plus a closure applied to
+  each row as `buy.ReadPage` loads it. Server-side: name, level range, quality,
+  usable. Client-side: exact, buyout-only, fully-stacked, tooltip substring.
+- **`exact`**, **buyout-only**, **fully-stacked-only**, and **tooltip
+  substring** — including the `container/bag/tooltip/8` vs `container/bag/8`
+  disambiguation, which is a test.
+- **Semicolon OR** browses as ONE list: `buy.NextPage` rolls past the last page
+  of a term into the next term rather than stopping. (`PrevPage` crossing
+  backwards lands on the previous term's *first* page — we don't know its page
+  count until we query it, and a round trip just to deep-link "its last page"
+  isn't worth it.)
+- Quick wins: right-click a bag item on the Buy tab to search it (Sell tab's
+  right-click-to-slot untouched — each fires only on its own tab), shift-click
+  any item anywhere to search it, Tab-completion from every learned item name.
+
+**Two notes for 2b/2d:**
+
+1. `class`/`subclass`/`slot` keywords are **not** in this slice. They need
+   index maps built from `GetAuctionItemClasses` / `GetAuctionItemSubClasses` /
+   inventory-type constants; the Filter Builder (2b) needs those same maps for
+   its dropdowns, so build them once there and let the parser share them.
+2. This slice's post-filters all apply together — an implicit AND. Prefix
+   `and`/`or`/`not` combination is 2d's job, and `CompileTerm`'s single
+   `filter` closure is the seam it should compose into.
+
+**Watch out for** (found the hard way): `local a, b = cond and f()` silently
+drops `f`'s second return whenever `and` truncates to one value. Cost a
+half-parsed level range until a test caught it.
+
+**Also fixed on the way:** `core/buy.lua` was folding every browsed listing
+into the price DB, which `core/scan.lua`'s `RecordVisiblePage` already does for
+every result page anyone looks at — same event, identical values. The duplicate
+is gone; the price feed still works because it always came from scan.lua.
 
 ### 2b — Filter Builder tab
 Form-driven query construction mirroring aux's layout (Name / Level Range /

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -307,9 +307,19 @@ single `filter` closure is the seam it should compose into.
   "until one comes back empty" walks off the end of the current tooltip into
   whatever longer tooltip was shown before. Bound the loop with `NumLines()`,
   and copy `sell.lua`'s owner → clear → set sequence rather than inventing one.
-- **A filter that needs `GetItemInfo` must fail OPEN.** It only answers for
-  cached items, so failing closed empties the entire page on a cold cache and
-  looks exactly like "no matches exist".
+- **Do not build a filter on `GetItemInfo` at all if you can avoid it.** The
+  fully-stacked filter took four attempts: fail-closed emptied every page,
+  fail-open filtered nothing, and two different theories about which return
+  slot holds the stack count were both wrong in the field. What finally worked
+  was letting the user state the number (`stack 20`) so no item lookup is
+  needed, with a page-derived fallback for the bare form. When a 1.12 API is
+  this unreliable, prefer a design that does not need it over a cleverer way
+  of calling it.
+- **`GetItemInfo`'s return list is not the same on every client** -- vanilla
+  1.12 has no `itemLevel`, so every slot after position 3 shifts by one
+  against later clients. Never index it positionally. `stackCount` is the last
+  NUMBER in the list on both, which is how `buy.StackCountFromItemInfo` finds
+  it.
 - **`canUse` from `GetAuctionItemInfo` is `1`-or-`nil`** — `nil` means cannot
   use, not "unknown". Treating nil as unknown made a warning unreachable for
   the entire life of the Buy tab.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -329,16 +329,55 @@ into the price DB, which `core/scan.lua`'s `RecordVisiblePage` already does for
 every result page anyone looks at — same event, identical values. The duplicate
 is gone; the price feed still works because it always came from scan.lua.
 
-### 2b — Filter Builder tab
-Form-driven query construction mirroring aux's layout (Name / Level Range /
-Item Class / Subclass / Slot / Min Quality on one side for the Blizzard
-filter, primitives + combination on the other for post-filters) — but
-**more efficient than aux's**, per your ask: aux requires hand-typing
-arity-prefixed operators (`and2`, `or3`, ...) to nest conditions correctly,
-which is a well-known rough edge. Aegis's builder manages that nesting
-automatically — click **+ Condition**, pick AND/OR, and the generated query
-string is always correctly nested without the user ever typing polish
-notation by hand. Search / Export / Import actions, same as aux.
+### 2b — Filter Builder tab — ✅ **DONE** (v1.7.0)
+Form-driven query construction, reached from the **Results / Builder** switch
+on the Buy tab (the Shopping Lists sidebar is untouched). Layout mirrors aux's:
+Name / Exact / Level Range / Item Class / Subclass / Slot / Min Quality /
+Usable on the Blizzard-filter side, post-filter primitives on the other.
+Search / Export / Import, same as aux — but the user never types polish
+notation, which was the whole point.
+
+**How it stays honest — round-trip is the acceptance test.** The form emits a
+string, the string parses back to a term, and the term repaints the form.
+That is checked **by value, not by string**: `buy.TermsEqual` compares all 13
+term keys (normalising `false` → `nil`), so a cosmetic difference in how the
+string was spelled can't mask a dropped field. 15 engine-level cases cover it,
+and they were written *before* any UI existed on top.
+
+**Settled while building it:**
+
+- **Dropdowns read `buy.Categories()` / `buy.SlotOptions()`** — the same maps
+  `armor/leather` searches through, exactly as this file asked. No parallel
+  category table exists anywhere in the addon.
+- **Class gates Subclass gates Slot.** Changing the class repopulates the
+  subclass list and drops a subclass the new class doesn't offer; same one
+  level down. `SetOptions` enforces that itself rather than trusting the
+  gating callback — a sabotage proved the callback alone would have hidden it.
+- **`buy.TermToQuery` emits in a fixed order**: name first, then
+  class/subclass/slot, then quality/level/usable/buyout/stack, **tooltip
+  last**. Not cosmetic — `container/bag/tooltip/8` only disambiguates from
+  `container/bag/8` if tooltip text can't be mistaken for a trailing category
+  token.
+- **The form edits ONE term.** `+ OR` appends it to the query box as a
+  semicolon term, which is the only combinator the engine has today.
+  Prefix `and`/`or`/`not` over post-filters is still **2d's** job, and the
+  builder's nesting-free promise above is a claim about 2d's UI, not this
+  slice's.
+- **Dropdowns are hand-built from `Frame` + `Button`**, following
+  `MakeHSlider`'s precedent, rather than inheriting a `UIDropDownMenu`
+  template whose 1.12 helper surface we couldn't verify against the Turtle UI
+  source. Popups parent to `ui.frame` so they aren't clipped by the panel;
+  one module-level `openDropdown` closes the previous one.
+- **Repainting the form must not fire the gating callbacks** — `SetValue(v,
+  silent)` and a `ui.builderPainting` re-entry guard, or importing a query
+  clears the very fields it just set.
+
+**Precursor shipped with it:** `util.ItemInfo(link)` normalises `GetItemInfo`
+into a named table (`name, link, quality, minLevel, type, subType, stackCount,
+equipLoc, texture`) by locating `stackCount` as the last number in the list, so
+the vanilla-vs-later 9/10-value shift can't bite again. `sell.ScanBags` and
+`buy.StackCountFromItemInfo` both route through it; **no caller indexes
+`GetItemInfo` positionally any more**, and the suite runs under both layouts.
 
 ### 2c — Saved Searches tab
 Favorites and Recent, styled after aux's split-column layout. Hover for a

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -318,6 +318,42 @@ function buy.Categories()
     return categoryCache
 end
 
+-- Look a typed word up in one of those name -> index maps.
+--
+-- Exact match is not enough on its own: the game's own category names are
+-- PLURAL and often qualified ("Daggers", "One-Handed Swords", "Food & Drink"),
+-- while people type the singular. `weapon/dagger` matched nothing, fell back
+-- to name text, and returned every thrown weapon with "Dagger" in its name --
+-- which is exactly how it got reported.
+--
+-- So: exact, then a unique prefix, then a unique substring. UNIQUE is the
+-- whole safety property -- "sword" matches both One-Handed and Two-Handed
+-- Swords, so it stays name text rather than silently picking one and
+-- returning a confidently wrong page.
+local function ResolveCategory(map, tok)
+    if not map then return nil end
+    local exact = map[tok]
+    if exact then return exact end
+
+    local found, count = nil, 0
+    for name, index in pairs(map) do
+        if string.find(name, tok, 1, true) == 1 then
+            found, count = index, count + 1
+        end
+    end
+    if count == 1 then return found end
+    if count > 1 then return nil end   -- ambiguous prefix: do not guess
+
+    found, count = nil, 0
+    for name, index in pairs(map) do
+        if string.find(name, tok, 1, true) then
+            found, count = index, count + 1
+        end
+    end
+    if count == 1 then return found end
+    return nil
+end
+
 -- The AH session teaches us these names; drop the cache when it ends so a
 -- different locale or a late-loading client can rebuild.
 function buy.ResetCategories()
@@ -436,15 +472,14 @@ function buy.ParseTerm(text)
             -- tooltip clause: after `tooltip` every word is search text, so
             -- searching tooltips for the literal word "bag" still works.
             elseif not term.inTooltip and not term.class
-                and cats.classes[tok] then
-                term.class = cats.classes[tok]
+                and ResolveCategory(cats.classes, tok) then
+                term.class = ResolveCategory(cats.classes, tok)
             elseif not term.inTooltip and term.class and not term.subclass
-                and cats.subclasses[term.class]
-                and cats.subclasses[term.class][tok] then
-                term.subclass = cats.subclasses[term.class][tok]
+                and ResolveCategory(cats.subclasses[term.class], tok) then
+                term.subclass = ResolveCategory(cats.subclasses[term.class], tok)
             elseif not term.inTooltip and term.class and not term.slot
-                and SlotsFor(term.class, term.subclass)[tok] then
-                term.slot = SlotsFor(term.class, term.subclass)[tok]
+                and ResolveCategory(SlotsFor(term.class, term.subclass), tok) then
+                term.slot = ResolveCategory(SlotsFor(term.class, term.subclass), tok)
             else
                 appendWord(raw)
             end
@@ -476,20 +511,42 @@ function buy.ParseQuery(text)
     return terms
 end
 
--- Item link -> cached max stack size, or nil (not yet client-cached). Used by
--- the "stack" (fully-stacked-only) post-filter.
+-- Max stack size for an item, or nil if genuinely not known yet.
+--
+-- The ONLY 1.12 source is GetItemInfo's 8th return, and it answers only for
+-- items already in the client's local item cache -- exactly the wrong
+-- behaviour for an auction house, where the items you have never handled are
+-- the ones you are shopping for. sell.lua already documents the same hazard.
+--
+-- So: check what we have LEARNED first, ask the client second, and persist
+-- anything the client does tell us. Over a couple of sessions the DB fills in
+-- and the filter stops guessing.
 buy.stackCache = {}
 function buy.MaxStackFor(itemId, link)
     if not itemId then return nil end
     local cached = buy.stackCache[itemId]
     if cached then return cached end
+    local stored = A.db and A.db.GetMaxStack and A.db.GetMaxStack(itemId)
+    if stored then
+        buy.stackCache[itemId] = stored
+        return stored
+    end
     if not link then return nil end
     local _, _, _, _, _, _, _, stackCount = GetItemInfo(link)
     if stackCount and stackCount > 0 then
         buy.stackCache[itemId] = stackCount
+        buy.LearnMaxStack(itemId, stackCount)
         return stackCount
     end
     return nil
+end
+
+-- Record a max stack we just learned, from wherever. Cheap and idempotent, so
+-- every code path that happens to hold a good GetItemInfo result can call it.
+function buy.LearnMaxStack(itemId, count)
+    if not itemId or not count or count < 1 then return end
+    buy.stackCache[itemId] = count
+    if A.db and A.db.SetMaxStack then A.db.SetMaxStack(itemId, count) end
 end
 
 -- A dedicated, never-shown tooltip for reading an auction listing's tooltip
@@ -554,7 +611,7 @@ function buy.CompileTerm(term)
     local buyoutOnly = term.buyoutOnly
     local stackOnly  = term.stackOnly
 
-    local function filter(row)
+    local function filter(row, stats)
         if buyoutOnly and not (row.buyout and row.buyout > 0) then
             return false
         end
@@ -562,14 +619,16 @@ function buy.CompileTerm(term)
             return false
         end
         if stackOnly then
-            -- Fails OPEN when the max stack is unknown. GetItemInfo only
-            -- answers for items in the client's cache, so on a cold cache
-            -- "not max" was true for every row and /stack returned an empty
-            -- page -- indistinguishable from "no full stacks exist", which is
-            -- exactly how it got reported as broken. Showing a few partial
-            -- stacks until the cache warms is the better failure.
+            -- An unknown max stack EXCLUDES the row -- "keep it just in case"
+            -- was worse: it let every partial stack through, so /stack looked
+            -- like it did nothing at all. But a silent exclusion looks equally
+            -- broken, so the count is reported and the caller surfaces it.
             local max = buy.MaxStackFor(row.itemId, row.link)
-            if max and row.count ~= max then return false end
+            if not max then
+                if stats then stats.unknownStack = (stats.unknownStack or 0) + 1 end
+                return false
+            end
+            if row.count ~= max then return false end
         end
         if tooltipNeedle and not TooltipContainsAt(row.index, tooltipNeedle) then
             return false
@@ -773,13 +832,21 @@ function buy.ReadPage()
 
     -- A plain-text search (the common case) compiles to an always-true filter,
     -- so rows == rawRows and nothing about existing behaviour changes.
+    local stats = { unknownStack = 0 }
     local rows = {}
     local ri = 1
     while ri <= table.getn(rawRows) do
         local r = rawRows[ri]
-        if term.filter(r) then table.insert(rows, r) end
+        -- Learn every max stack this page happens to expose, whether or not
+        -- the row survives the filter -- the next search benefits either way.
+        if r.itemId and r.link then
+            local _, _, _, _, _, _, _, sc = GetItemInfo(r.link)
+            if sc and sc > 0 then buy.LearnMaxStack(r.itemId, sc) end
+        end
+        if term.filter(r, stats) then table.insert(rows, r) end
         ri = ri + 1
     end
+    st.stats = stats
 
     -- Cheapest unit buyout first (bid-only auctions, unit = nil, sink to the
     -- bottom); the real `index` is preserved so buying still hits the right
@@ -852,7 +919,7 @@ end
 function buy.GetResults()
     local st = buy.state
     return st.rows, st.page, st.totalPages, st.total, st.termIndex,
-        table.getn(st.terms)
+        table.getn(st.terms), st.stats
 end
 
 -- ---------------------------------------------------------------------------

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -511,12 +511,43 @@ function buy.ParseQuery(text)
     return terms
 end
 
+-- Max stack size out of a GetItemInfo call, WITHOUT counting return slots.
+--
+-- The return list differs between clients:
+--   vanilla 1.12   name, link, quality, minLevel, type, subType,
+--                  stackCount, equipLoc, texture              (9 values)
+--   later clients  ...insert itemLevel at position 4, pushing
+--                  everything after it down one                (10 values)
+--
+-- So a fixed index reads stackCount on one client and equipLoc on the other.
+-- That is what made `/stack` report "stack size unknown" for a stack of Silk
+-- Cloth sitting in the player's own bags: reading slot 8 got equipLoc, which
+-- is empty for a trade good -- and would have thrown outright on a piece of
+-- gear, where equipLoc is a string like "INVTYPE_CHEST".
+--
+-- In BOTH layouts stackCount is the LAST NUMBER in the list -- everything
+-- after it (equipLoc, texture) is a string. Find that instead of counting.
+local function StackCountFromItemInfo(link)
+    if not link then return nil end
+    local r = { GetItemInfo(link) }
+    local i = table.getn(r)
+    while i >= 1 do
+        if type(r[i]) == "number" then
+            if r[i] > 0 then return r[i] end
+            return nil
+        end
+        i = i - 1
+    end
+    return nil
+end
+buy.StackCountFromItemInfo = StackCountFromItemInfo
+
 -- Max stack size for an item, or nil if genuinely not known yet.
 --
--- The ONLY 1.12 source is GetItemInfo's 8th return, and it answers only for
--- items already in the client's local item cache -- exactly the wrong
--- behaviour for an auction house, where the items you have never handled are
--- the ones you are shopping for. sell.lua already documents the same hazard.
+-- GetItemInfo only answers for items already in the client's local item cache
+-- -- exactly the wrong behaviour for an auction house, where the items you
+-- have never handled are the ones you are shopping for. sell.lua already
+-- documents the same hazard.
 --
 -- So: check what we have LEARNED first, ask the client second, and persist
 -- anything the client does tell us. Over a couple of sessions the DB fills in
@@ -531,10 +562,8 @@ function buy.MaxStackFor(itemId, link)
         buy.stackCache[itemId] = stored
         return stored
     end
-    if not link then return nil end
-    local _, _, _, _, _, _, _, stackCount = GetItemInfo(link)
-    if stackCount and stackCount > 0 then
-        buy.stackCache[itemId] = stackCount
+    local stackCount = StackCountFromItemInfo(link)
+    if stackCount then
         buy.LearnMaxStack(itemId, stackCount)
         return stackCount
     end
@@ -840,8 +869,8 @@ function buy.ReadPage()
         -- Learn every max stack this page happens to expose, whether or not
         -- the row survives the filter -- the next search benefits either way.
         if r.itemId and r.link then
-            local _, _, _, _, _, _, _, sc = GetItemInfo(r.link)
-            if sc and sc > 0 then buy.LearnMaxStack(r.itemId, sc) end
+            local sc = StackCountFromItemInfo(r.link)
+            if sc then buy.LearnMaxStack(r.itemId, sc) end
         end
         if term.filter(r, stats) then table.insert(rows, r) end
         ri = ri + 1

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -790,7 +790,16 @@ function buy.CompileTerm(term)
         subclass = term.subclass,
         invType  = term.slot,
     }
-    local exactName = term.exact and string.lower(term.name or "") or nil
+    -- Exact only means something when there IS a name. Guarding the empty
+    -- string matters because "" is truthy in Lua: `term.exact and
+    -- lower(term.name or "")` yields exactName == "" for a nameless term, and
+    -- since no listing is named "", that filtered out EVERY row on EVERY page
+    -- -- an Exact checkbox ticked with an empty Name field could never return
+    -- a single result, whatever else the form said.
+    local exactName
+    if term.exact and term.name and term.name ~= "" then
+        exactName = string.lower(term.name)
+    end
     local tooltipNeedle = term.tooltipText and string.lower(term.tooltipText)
         or nil
     local buyoutOnly = term.buyoutOnly

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -280,7 +280,8 @@ end
 local categoryCache
 
 local function BuildCategoryCache()
-    local cache = { classes = {}, subclasses = {}, slots = {} }
+    local cache = { classes = {}, subclasses = {}, slots = {},
+                    classNames = {}, subNames = {}, slotNames = {} }
     if not GetAuctionItemClasses then return cache end
     local cats = A.scan and A.scan.GetCategories and A.scan.GetCategories()
     if not cats then return cache end
@@ -289,6 +290,7 @@ local function BuildCategoryCache()
         local cat = cats[ci]
         if cat.name then
             cache.classes[string.lower(cat.name)] = cat.class
+            cache.classNames[cat.class] = cat.name
             local subs = cat.subs or {}
             local si = 1
             while si <= table.getn(subs) do
@@ -304,6 +306,10 @@ local function BuildCategoryCache()
                         cache.subclasses[cat.class] = byClass
                     end
                     byClass[string.lower(sub.name)] = sub.subclass
+                    -- Reverse map, for the Filter Builder: it has to render
+                    -- the localized name for an index it holds.
+                    cache.subNames[cat.class] = cache.subNames[cat.class] or {}
+                    cache.subNames[cat.class][sub.subclass] = sub.name
                 end
                 si = si + 1
             end
@@ -360,6 +366,41 @@ function buy.ResetCategories()
     categoryCache = nil
 end
 
+-- Reverse lookups: an index back to the localized name. The Filter Builder
+-- holds indices (that is what the query carries) but must SHOW names.
+function buy.ClassName(class)
+    local c = buy.Categories()
+    return class and c.classNames[class] or nil
+end
+
+function buy.SubclassName(class, subclass)
+    local c = buy.Categories()
+    local m = class and c.subNames[class]
+    return m and subclass and m[subclass] or nil
+end
+
+-- Ordered { { value = index, text = name } } lists for the builder's dropdowns.
+-- Sorted by index so the order matches the auction house's own dropdowns
+-- rather than alphabetically by whatever the locale happens to call things.
+local function OptionsFrom(nameMap)
+    local out = {}
+    if not nameMap then return out end
+    for idx, name in pairs(nameMap) do
+        table.insert(out, { value = idx, text = name })
+    end
+    table.sort(out, function(a, b) return a.value < b.value end)
+    return out
+end
+
+function buy.ClassOptions()
+    return OptionsFrom(buy.Categories().classNames)
+end
+
+function buy.SubclassOptions(class)
+    if not class then return {} end
+    return OptionsFrom(buy.Categories().subNames[class])
+end
+
 -- Equip slots for a given class/subclass, lazily per pair. GetAuctionInvTypes
 -- is guarded: it is not present on every 1.12 build, and a nil call here would
 -- take the whole parse down.
@@ -380,6 +421,12 @@ local function SlotsFor(class, subclass)
                 local label = globalKey and getglobal(globalKey)
                 if label and label ~= "" then
                     found[string.lower(label)] = i
+                    local names = cache.slotNames[key]
+                    if not names then
+                        names = {}
+                        cache.slotNames[key] = names
+                    end
+                    names[i] = label
                 end
                 i = i + 1
             end
@@ -387,6 +434,30 @@ local function SlotsFor(class, subclass)
     end
     cache.slots[key] = found
     return found
+end
+
+-- Slot options / name. Both force SlotsFor first so the reverse map exists --
+-- it is only populated as a side effect of the forward lookup.
+function buy.SlotOptions(class, subclass)
+    if not class then return {} end
+    SlotsFor(class, subclass)
+    local key = tostring(class) .. ":" .. tostring(subclass or 0)
+    local out = {}
+    local names = buy.Categories().slotNames[key]
+    if not names then return out end
+    for idx, name in pairs(names) do
+        table.insert(out, { value = idx, text = name })
+    end
+    table.sort(out, function(a, b) return a.value < b.value end)
+    return out
+end
+
+function buy.SlotName(class, subclass, slot)
+    if not class or not slot then return nil end
+    SlotsFor(class, subclass)
+    local key = tostring(class) .. ":" .. tostring(subclass or 0)
+    local names = buy.Categories().slotNames[key]
+    return names and names[slot] or nil
 end
 
 -- "20" or "20-30" (the VALUE half of a two-token "level/..." form) -> min, max.
@@ -522,6 +593,83 @@ function buy.ParseTerm(text)
         term.tooltipText = nil
     end
     return term
+end
+
+-- ---------------------------------------------------------------------------
+-- Query generation (ROADMAP 2b -- the Filter Builder's other direction)
+-- ---------------------------------------------------------------------------
+
+-- Turn a parsed-term-shaped table back into a query string.
+--
+-- ORDER MATTERS and is not cosmetic. ParseTerm resolves a token as a subclass
+-- only once a class is known, and as a slot only after that -- so categories
+-- must be emitted class, subclass, slot, in that sequence. The name goes FIRST
+-- so its words are consumed as name text before any category token sets the
+-- class and starts eating them.
+--
+-- Round-tripping is by VALUE, not by string: a name that is itself a category
+-- word ("armor") re-parses into the same term with the tokens in a different
+-- order. Compare parsed terms, never the strings.
+function buy.TermToQuery(term)
+    if not term then return "" end
+    local parts = {}
+    local function add(p)
+        if p and p ~= "" then table.insert(parts, p) end
+    end
+
+    add(term.name)
+    if term.exact then add("exact") end
+
+    add(term.class and buy.ClassName(term.class))
+    add(term.class and term.subclass
+        and buy.SubclassName(term.class, term.subclass))
+    add(term.class and term.slot
+        and buy.SlotName(term.class, term.subclass, term.slot))
+
+    if term.quality then add("quality/" .. term.quality) end
+    if term.minLevel then
+        if term.maxLevel and term.maxLevel ~= term.minLevel then
+            add("level/" .. term.minLevel .. "-" .. term.maxLevel)
+        else
+            add("level/" .. term.minLevel)
+        end
+    end
+    if term.usable then add("usable") end
+    if term.buyoutOnly then add("buyout") end
+    if term.stackSize then
+        add("stack/" .. term.stackSize)
+    elseif term.stackOnly then
+        add("stack")
+    end
+    -- Tooltip LAST: everything after the keyword is swallowed as tooltip text,
+    -- so anything emitted after it would silently stop being a filter.
+    if term.tooltipText and term.tooltipText ~= "" then
+        add("tooltip/" .. term.tooltipText)
+    end
+
+    return table.concat(parts, "/")
+end
+
+-- Two parsed terms mean the same search? Used by the builder's round-trip
+-- check, and by its tests, because string equality is the wrong comparison
+-- (see TermToQuery).
+function buy.TermsEqual(a, b)
+    if not a or not b then return false end
+    local keys = { "name", "exact", "usable", "buyoutOnly", "stackOnly",
+                   "stackSize", "quality", "minLevel", "maxLevel",
+                   "class", "subclass", "slot", "tooltipText" }
+    local i = 1
+    while i <= table.getn(keys) do
+        local k = keys[i]
+        -- false and nil both mean "off" for the flags; normalise before
+        -- comparing so an unset checkbox matches an absent field.
+        local av, bv = a[k], b[k]
+        if av == false then av = nil end
+        if bv == false then bv = nil end
+        if av ~= bv then return false end
+        i = i + 1
+    end
+    return true
 end
 
 -- Split on the top-level semicolon OR, into an array of parsed terms. Always

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -28,7 +28,10 @@ buy.TIMEOUT     = 8      -- seconds to wait for a page reply before retrying
 buy.state = {
     phase      = "idle",   -- idle | wait_query | wait_results
     name       = "",
-    page       = 0,        -- 0-indexed current page
+    terms      = { { blizz = { name = "", minLevel = "", maxLevel = "" },
+                      filter = function() return true end } },
+    termIndex  = 1,        -- 1-based: which OR term (see Query language below)
+    page       = 0,        -- 0-indexed current page, WITHIN the active term
     totalPages = 0,
     total      = 0,
     rows       = {},       -- current page's listings (sorted for display)
@@ -93,6 +96,33 @@ function buy.PushRecent(term)
     end
 end
 
+-- Tab-autocomplete candidates for the search box: known item names (learned
+-- from every scan, search, or AH browse -- db.account.names is fed from all
+-- three) plus recent search terms, case-insensitive PREFIX match, deduped,
+-- alphabetical.
+function buy.AutocompleteCandidates(prefix)
+    local out = {}
+    if not prefix or prefix == "" then return out end
+    local low = string.lower(prefix)
+    local seen = {}
+    local function consider(name)
+        if not name or name == "" or seen[name] then return end
+        if string.find(string.lower(name), low, 1, true) == 1 then
+            seen[name] = true
+            table.insert(out, name)
+        end
+    end
+    local names = A.db and A.db.account and A.db.account.names
+    if names then
+        for name in pairs(names) do consider(name) end
+    end
+    local recent = buy.Recent()
+    local i = 1
+    while i <= table.getn(recent) do consider(recent[i]); i = i + 1 end
+    table.sort(out)
+    return out
+end
+
 function buy.AddList(name)
     local s = Store()
     if not s or not name or name == "" then return nil end
@@ -145,19 +175,286 @@ function buy.RemoveItemFromList(index, itemName)
     end
 end
 
--- Kick off a fresh search for `name` at page 0.
-function buy.Search(name, callbacks)
+-- ---------------------------------------------------------------------------
+-- Query language (ROADMAP Phase 2a)
+--
+-- The grammar is aux's, not a new Aegis-native dialect (decided in ROADMAP.md):
+-- slash-delimited terms, semicolon-separated OR at the top level, keyword
+-- modifiers. This is an ORIGINAL implementation of that known grammar shape --
+-- no code from any reference addon.
+--
+-- Nothing about today's casual usage changes: typing a plain item name still
+-- just searches by name, because a bare word with no recognized keyword is
+-- exactly what it always was -- text appended to the name filter.
+--
+-- Recognized tokens (slash-delimited), case-insensitive:
+--   exact              -- keep only rows whose AUCTION NAME matches the typed
+--                          name exactly (not just "contains"). Post-filter.
+--   usable             -- server-side isUsable flag.
+--   quality/<n-or-name> or the fused form qualityN (e.g. "quality2") --
+--                          server-side quality index. Names: poor, common,
+--                          uncommon, rare, epic, legendary.
+--   level/<n> or level/<min>-<max>, or the fused forms levelN / levelN-M --
+--                          server-side level range.
+--   buyout             -- exclude bid-only auctions. Post-filter.
+--   stack              -- keep only fully-stacked listings (count == the
+--                          item's max stack size). Post-filter.
+--   tooltip            -- everything AFTER this point in the term accumulates
+--                          into a tooltip-substring search instead of the name
+--                          (post-filter, scans the auction's tooltip lines).
+--                          Concrete disambiguation case:
+--                            container/bag/tooltip/8  -> name "container bag",
+--                                                         tooltip "8"
+--                            container/bag/8          -> name "container bag 8"
+--
+-- DEFERRED (not in this slice, so the grammar accepts but does not yet act on
+-- them beyond folding them into the name text -- see ROADMAP.md 2a):
+--   class/subclass/slot keywords (need GetAuctionItemClasses/SubClasses/
+--   InvTypes index maps); exact's fuller promise of tightening those same
+--   fields server-side; price/time-left post-filter primitives beyond
+--   buyout/stack; prefix-notation and/or/not combinators (2d's territory --
+--   this slice's post-filters simply all apply together, an implicit AND).
+-- ---------------------------------------------------------------------------
+
+buy.QUALITY_NAMES = {
+    poor = 0, common = 1, uncommon = 2, rare = 3, epic = 4, legendary = 5,
+}
+
+-- "2" or "rare" -> a quality index, or nil if neither parses.
+local function ParseQualityValue(tok)
+    local named = buy.QUALITY_NAMES[tok]
+    if named then return named end
+    local n = tonumber(tok)
+    if n and n >= 0 and n <= 6 then return math.floor(n) end
+    return nil
+end
+
+-- Fused "quality2" / "qualityrare" -> a quality index, or nil.
+local function ParseFusedQuality(tok)
+    local _, _, digits = string.find(tok, "^quality(%d+)$")
+    if digits then return tonumber(digits) end
+    local _, _, name = string.find(tok, "^quality(%a+)$")
+    if name then return buy.QUALITY_NAMES[name] end
+    return nil
+end
+
+-- "20" or "20-30" (the VALUE half of a two-token "level/..." form) -> min, max.
+local function ParseLevelValue(tok)
+    local _, _, mn, mx = string.find(tok, "^(%d+)%-(%d+)$")
+    if mn then return tonumber(mn), tonumber(mx) end
+    local _, _, single = string.find(tok, "^(%d+)$")
+    if single then local n = tonumber(single); return n, n end
+    return nil
+end
+
+-- Fused "level20" / "level20-30" -> min, max, or nil.
+local function ParseFusedLevel(tok)
+    local _, _, mn, mx = string.find(tok, "^level(%d+)%-(%d+)$")
+    if mn then return tonumber(mn), tonumber(mx) end
+    local _, _, single = string.find(tok, "^level(%d+)$")
+    if single then local n = tonumber(single); return n, n end
+    return nil
+end
+
+-- Parse ONE slash-delimited term (already split out of the semicolon OR list)
+-- into its structured pieces. Never errors: an unrecognized token always falls
+-- back to becoming literal name/tooltip text, so a query never "breaks".
+function buy.ParseTerm(text)
+    local term = {
+        nameWords = {}, tooltipWords = {}, inTooltip = false,
+        exact = false, usable = false, buyoutOnly = false, stackOnly = false,
+        quality = nil, minLevel = nil, maxLevel = nil,
+    }
+    local function appendWord(word)
+        if term.inTooltip then
+            table.insert(term.tooltipWords, word)
+        else
+            table.insert(term.nameWords, word)
+        end
+    end
+
+    local tokens = util.Split(text, "/")
+    local i, n = 1, table.getn(tokens)
+    while i <= n do
+        local raw = util.Trim(tokens[i])
+        local tok = string.lower(raw)
+        if tok == "exact" then
+            term.exact = true
+        elseif tok == "usable" then
+            term.usable = true
+        elseif tok == "buyout" then
+            term.buyoutOnly = true
+        elseif tok == "stack" then
+            term.stackOnly = true
+        elseif tok == "tooltip" then
+            term.inTooltip = true
+        elseif tok == "quality" then
+            local nxt = tokens[i + 1]
+            local q = nxt and ParseQualityValue(string.lower(util.Trim(nxt)))
+            if q then term.quality = q; i = i + 1
+            else appendWord(raw) end
+        elseif tok == "level" then
+            -- NOT "nxt and ParseLevelValue(...)": `and` adjusts its right
+            -- operand to a single value, which silently drops ParseLevelValue's
+            -- second return (maxLevel) whenever it truncates. Caught by a test
+            -- asserting level/20-30 keeps BOTH ends of the range.
+            local nxt = tokens[i + 1]
+            local mn, mx
+            if nxt then mn, mx = ParseLevelValue(util.Trim(nxt)) end
+            if mn then term.minLevel = mn; term.maxLevel = mx; i = i + 1
+            else appendWord(raw) end
+        else
+            local q = ParseFusedQuality(tok)
+            if q then
+                term.quality = q
+            else
+                local mn, mx = ParseFusedLevel(tok)
+                if mn then
+                    term.minLevel = mn; term.maxLevel = mx
+                else
+                    appendWord(raw)
+                end
+            end
+        end
+        i = i + 1
+    end
+
+    term.name = util.Trim(table.concat(term.nameWords, " "))
+    if table.getn(term.tooltipWords) > 0 then
+        term.tooltipText = util.Trim(table.concat(term.tooltipWords, " "))
+    else
+        term.tooltipText = nil
+    end
+    return term
+end
+
+-- Split on the top-level semicolon OR, into an array of parsed terms. Always
+-- returns at least one term (an all-blank query is one empty-name term, same
+-- as browsing everything today).
+function buy.ParseQuery(text)
+    local groups = util.Split(text or "", ";")
+    if table.getn(groups) == 0 then groups = { "" } end
+    local terms = {}
+    local i = 1
+    while i <= table.getn(groups) do
+        table.insert(terms, buy.ParseTerm(groups[i]))
+        i = i + 1
+    end
+    return terms
+end
+
+-- Item link -> cached max stack size, or nil (not yet client-cached). Used by
+-- the "stack" (fully-stacked-only) post-filter.
+buy.stackCache = {}
+function buy.MaxStackFor(itemId, link)
+    if not itemId then return nil end
+    local cached = buy.stackCache[itemId]
+    if cached then return cached end
+    if not link then return nil end
+    local _, _, _, _, _, _, _, stackCount = GetItemInfo(link)
+    if stackCount and stackCount > 0 then
+        buy.stackCache[itemId] = stackCount
+        return stackCount
+    end
+    return nil
+end
+
+-- A dedicated, never-shown tooltip used only to read an auction listing's
+-- tooltip text for the "tooltip" post-filter. 1.12 has no NumLines(); the
+-- stock technique (see CLAUDE.md rule 14) is getglobal on the template's
+-- numbered FontStrings until one comes back empty.
+local queryTip = CreateFrame("GameTooltip", "AegisExchangeQueryTooltip", nil,
+    "GameTooltipTemplate")
+queryTip:SetOwner(UIParent, "ANCHOR_NONE")
+
+local function TooltipContainsAt(index, needleLower)
+    if not queryTip.SetAuctionItem then return false end
+    queryTip:ClearLines()
+    queryTip:SetOwner(UIParent, "ANCHOR_NONE")
+    queryTip:SetAuctionItem("list", index)
+    local i = 1
+    while i <= 30 do
+        local fs = getglobal("AegisExchangeQueryTooltipTextLeft" .. i)
+        if not fs then break end
+        local text = fs:GetText()
+        if not text then break end
+        if string.find(string.lower(text), needleLower, 1, true) then
+            return true
+        end
+        i = i + 1
+    end
+    return false
+end
+
+-- Compile a parsed term into what the engine actually needs: the 1.12
+-- QueryAuctionItems args (CLAUDE.md rule 9: strings for name/min/max, "" when
+-- unused, never nil; flag/index args stay nil for "no filter") plus a
+-- post-filter closure applied to each row as its page loads.
+function buy.CompileTerm(term)
+    local blizz = {
+        name     = term.name or "",
+        minLevel = term.minLevel and tostring(term.minLevel) or "",
+        maxLevel = term.maxLevel and tostring(term.maxLevel) or "",
+        isUsable = term.usable and true or nil,
+        quality  = term.quality,
+    }
+    local exactName = term.exact and string.lower(term.name or "") or nil
+    local tooltipNeedle = term.tooltipText and string.lower(term.tooltipText)
+        or nil
+    local buyoutOnly = term.buyoutOnly
+    local stackOnly  = term.stackOnly
+
+    local function filter(row)
+        if buyoutOnly and not (row.buyout and row.buyout > 0) then
+            return false
+        end
+        if exactName and string.lower(row.name or "") ~= exactName then
+            return false
+        end
+        if stackOnly then
+            local max = buy.MaxStackFor(row.itemId, row.link)
+            if not max or row.count ~= max then return false end
+        end
+        if tooltipNeedle and not TooltipContainsAt(row.index, tooltipNeedle) then
+            return false
+        end
+        return true
+    end
+
+    return { blizz = blizz, filter = filter, raw = term }
+end
+
+function buy.CompileQuery(text)
+    local terms = buy.ParseQuery(text)
+    local compiled = {}
+    local i = 1
+    while i <= table.getn(terms) do
+        table.insert(compiled, buy.CompileTerm(terms[i]))
+        i = i + 1
+    end
+    return compiled
+end
+
+-- ---------------------------------------------------------------------------
+-- Browsing engine
+-- ---------------------------------------------------------------------------
+
+-- Kick off a fresh search for `text` (plain name, or the query language above)
+-- at term 1, page 0.
+function buy.Search(text, callbacks)
     if buy.IsBusy() then
         return false, "The AH is busy (scan or posting in progress)."
     end
     local st = buy.state
-    st.name      = name or ""
+    st.terms     = buy.CompileQuery(text)
+    st.termIndex = 1
+    st.name      = st.terms[1].blizz.name   -- kept for existing readers
     st.page      = 0
     st.callbacks = callbacks or st.callbacks
     st.phase     = "wait_query"
     st.cooldown  = 0
     st.timeout   = 0
-    buy.PushRecent(util.Trim(st.name))
+    buy.PushRecent(util.Trim(text or ""))
     buy.driver:Show()
     Notify()
     return true
@@ -184,22 +481,56 @@ function buy.GotoPage(page)
     Notify()
 end
 
+-- Switch the active OR term (see the Query language section above) and query
+-- its page 0.
+function buy.GotoTerm(termIndex)
+    if buy.IsBusy() then return end
+    local st = buy.state
+    local total = table.getn(st.terms)
+    if termIndex < 1 then termIndex = 1 end
+    if termIndex > total then termIndex = total end
+    st.termIndex = termIndex
+    st.name      = st.terms[termIndex].blizz.name   -- kept for existing readers
+    st.page      = 0
+    st.phase     = "wait_query"
+    st.cooldown  = buy.QUERY_DELAY
+    buy.driver:Show()
+    Notify()
+end
+
+-- Past the last page of the active term, roll into the next OR term rather
+-- than stopping -- a semicolon-separated query is meant to read as one
+-- combined browse, not N separate searches you have to notice and re-run.
 function buy.NextPage()
-    if buy.state.page + 1 < buy.state.totalPages then
-        buy.GotoPage(buy.state.page + 1)
+    local st = buy.state
+    if st.page + 1 < st.totalPages then
+        buy.GotoPage(st.page + 1)
+    elseif st.termIndex < table.getn(st.terms) then
+        buy.GotoTerm(st.termIndex + 1)
     end
 end
 
+-- Symmetric with NextPage, EXCEPT crossing a term boundary backwards lands on
+-- that term's FIRST page rather than a deep link to its last one -- we don't
+-- know its page count until we've queried it, and reaching back across an OR
+-- boundary is rare enough that a second round trip to discover "the last
+-- page" isn't worth the complexity.
 function buy.PrevPage()
-    if buy.state.page > 0 then
-        buy.GotoPage(buy.state.page - 1)
+    local st = buy.state
+    if st.page > 0 then
+        buy.GotoPage(st.page - 1)
+    elseif st.termIndex > 1 then
+        buy.GotoTerm(st.termIndex - 1)
     end
 end
 
 local function SendQuery()
     local st = buy.state
-    -- name/minLevel/maxLevel as strings (see CLAUDE.md rule 9).
-    QueryAuctionItems(st.name or "", "", "", nil, nil, nil, st.page, nil, nil)
+    local b = st.terms[st.termIndex].blizz
+    -- name/minLevel/maxLevel as strings (see CLAUDE.md rule 9); index/flag
+    -- args (isUsable, quality) stay nil for "no filter".
+    QueryAuctionItems(b.name, b.minLevel, b.maxLevel, nil, nil, nil,
+        st.page, b.isUsable, b.quality)
     st.phase   = "wait_results"
     st.timeout = buy.TIMEOUT
     Notify()
@@ -226,13 +557,14 @@ buy.driver:SetScript("OnUpdate", function() buy.OnUpdate(arg1) end)
 -- real `index` so a later bid/buyout targets the right auction.
 function buy.ReadPage()
     local st = buy.state
+    local term = st.terms[st.termIndex]
     local numOnPage, total = GetNumAuctionItems("list")
     st.total = total or 0
     st.totalPages = math.ceil(st.total / buy.PAGE_SIZE)
     if st.totalPages < 1 then st.totalPages = 1 end
 
     local me = UnitName and UnitName("player") or nil
-    local rows = {}
+    local rawRows = {}
     local i = 1
     while i <= numOnPage do
         local name, texture, count, quality, canUse, level, minBid, minInc,
@@ -245,7 +577,8 @@ function buy.ReadPage()
             else
                 nextBid = minBid or 0
             end
-            table.insert(rows, {
+            local link = GetAuctionItemLink("list", i)
+            table.insert(rawRows, {
                 index   = i,
                 name    = name,
                 texture = texture,
@@ -260,22 +593,34 @@ function buy.ReadPage()
                 bidAmount = bidAmount or 0,
                 nextBid = nextBid,
                 owner   = owner,
-                itemId  = util.ItemIdFromLink(GetAuctionItemLink("list", i)),
+                link    = link,
+                itemId  = util.ItemIdFromLink(link),
                 mine    = (owner and me and owner == me) and true or false,
             })
         end
         i = i + 1
     end
 
-    -- Ordinary browsing feeds the price DB too (not just full scans): fold each
-    -- listing's unit buyout into today's daily minimum. This is what makes the
-    -- % market column and the crafting profit estimate work off searches alone.
+    -- NOTE: browsing DOES feed the price DB, but not from here. scan.lua's
+    -- AUCTION_ITEM_LIST_UPDATE handler calls RecordVisiblePage() on every
+    -- result page anyone looks at -- including this one, from the same event
+    -- -- so a loop here would just record the identical values a second time.
+    -- (This file used to do exactly that. Adding the post-filter below is what
+    -- surfaced it: a sabotage that fed the DB from the FILTERED rows instead
+    -- of the raw ones changed nothing observable, because scan.lua had already
+    -- recorded every row regardless.)
+    --
+    -- The important consequence is worth stating: the post-filter narrows what
+    -- is DISPLAYED and never what is learned. A "buyout only" or "exact"
+    -- search still teaches the price DB what every listing on the page costs.
+
+    -- A plain-text search (the common case) compiles to an always-true filter,
+    -- so rows == rawRows and nothing about existing behaviour changes.
+    local rows = {}
     local ri = 1
-    while ri <= table.getn(rows) do
-        local r = rows[ri]
-        if r.itemId and r.unit then
-            A.db.RecordAuction(r.itemId, r.unit, r.name)
-        end
+    while ri <= table.getn(rawRows) do
+        local r = rawRows[ri]
+        if term.filter(r) then table.insert(rows, r) end
         ri = ri + 1
     end
 
@@ -348,7 +693,9 @@ function buy.Bid(row, amount)
 end
 
 function buy.GetResults()
-    return buy.state.rows, buy.state.page, buy.state.totalPages, buy.state.total
+    local st = buy.state
+    return st.rows, st.page, st.totalPages, st.total, st.termIndex,
+        table.getn(st.terms)
 end
 
 -- ---------------------------------------------------------------------------

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -199,30 +199,56 @@ end
 --   buyout             -- exclude bid-only auctions. Post-filter.
 --   stack              -- keep only fully-stacked listings (count == the
 --                          item's max stack size). Post-filter.
+--   <class name>       -- an auction CATEGORY, by its own localized name:
+--                          "armor", "weapon", "container", "trade goods", ...
+--   <subclass name>    -- a subcategory of whatever class was named earlier in
+--                          the same term: "armor/leather", "container/bag".
+--   <slot name>        -- an equip slot within the current class/subclass,
+--                          e.g. "armor/plate/chest".
 --   tooltip            -- everything AFTER this point in the term accumulates
 --                          into a tooltip-substring search instead of the name
 --                          (post-filter, scans the auction's tooltip lines).
---                          Concrete disambiguation case:
---                            container/bag/tooltip/8  -> name "container bag",
---                                                         tooltip "8"
---                            container/bag/8          -> name "container bag 8"
+--                          Concrete disambiguation case, both with class
+--                          Container / subclass Bag consumed as categories:
+--                            container/bag/tooltip/8  -> tooltip contains "8"
+--                            container/bag/8          -> name contains "8"
 --
--- DEFERRED (not in this slice, so the grammar accepts but does not yet act on
--- them beyond folding them into the name text -- see ROADMAP.md 2a):
---   class/subclass/slot keywords (need GetAuctionItemClasses/SubClasses/
---   InvTypes index maps); exact's fuller promise of tightening those same
---   fields server-side; price/time-left post-filter primitives beyond
---   buyout/stack; prefix-notation and/or/not combinators (2d's territory --
---   this slice's post-filters simply all apply together, an implicit AND).
+-- DEFERRED (see ROADMAP.md): price/time-left/seller/rarity post-filter
+-- primitives; prefix-notation and/or/not combinators (2d's territory -- this
+-- slice's post-filters all apply together, an implicit AND).
+--
+-- NOTE on `exact`: aux's Filter Builder DISABLES the level/class/quality
+-- controls when exact is ticked. We deliberately don't -- ours is a pure
+-- post-filter on the name, so combining it with a category or level range is
+-- both harmless and occasionally useful, and silently dropping filters someone
+-- typed would be worse than honouring them.
 -- ---------------------------------------------------------------------------
 
+-- Quality names, keyed by the client's OWN localized strings first
+-- (ITEM_QUALITY<n>_DESC is how the game names them, and is what aux reads),
+-- with the English words kept as a fallback so the documented `quality/rare`
+-- spelling works even somewhere the globals are missing.
 buy.QUALITY_NAMES = {
     poor = 0, common = 1, uncommon = 2, rare = 3, epic = 4, legendary = 5,
 }
 
+local qualityByName
+local function QualityNames()
+    if qualityByName then return qualityByName end
+    qualityByName = {}
+    for word, idx in pairs(buy.QUALITY_NAMES) do qualityByName[word] = idx end
+    local i = 0
+    while i <= 5 do
+        local desc = getglobal("ITEM_QUALITY" .. i .. "_DESC")
+        if desc and desc ~= "" then qualityByName[string.lower(desc)] = i end
+        i = i + 1
+    end
+    return qualityByName
+end
+
 -- "2" or "rare" -> a quality index, or nil if neither parses.
 local function ParseQualityValue(tok)
-    local named = buy.QUALITY_NAMES[tok]
+    local named = QualityNames()[tok]
     if named then return named end
     local n = tonumber(tok)
     if n and n >= 0 and n <= 6 then return math.floor(n) end
@@ -234,8 +260,97 @@ local function ParseFusedQuality(tok)
     local _, _, digits = string.find(tok, "^quality(%d+)$")
     if digits then return tonumber(digits) end
     local _, _, name = string.find(tok, "^quality(%a+)$")
-    if name then return buy.QUALITY_NAMES[name] end
+    if name then return QualityNames()[name] end
     return nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Auction categories (class / subclass / slot)
+--
+-- Resolved from the client's OWN localized names, exactly as aux does:
+-- GetAuctionItemClasses() -> class names, GetAuctionItemSubClasses(class) ->
+-- its subclass names, GetAuctionInvTypes(class, subclass) -> GLOBAL KEY
+-- strings ("INVTYPE_CHEST") whose _G lookup is the display name. Hard-coding
+-- English would have made "armor/leather" a non-English-client-only feature.
+--
+-- Built lazily and cached: these APIs only answer once the AH is open, so
+-- building at file scope would bake in an empty table forever.
+-- ---------------------------------------------------------------------------
+
+local categoryCache
+
+local function BuildCategoryCache()
+    local cache = { classes = {}, subclasses = {}, slots = {} }
+    if not GetAuctionItemClasses then return cache end
+    local cats = A.scan and A.scan.GetCategories and A.scan.GetCategories()
+    if not cats then return cache end
+    local ci = 1
+    while ci <= table.getn(cats) do
+        local cat = cats[ci]
+        if cat.name then
+            cache.classes[string.lower(cat.name)] = cat.class
+            local subs = cat.subs or {}
+            local si = 1
+            while si <= table.getn(subs) do
+                local sub = subs[si]
+                if sub.name then
+                    -- Keyed by class: subclass names repeat across classes
+                    -- ("Miscellaneous" lives under several), so a flat map
+                    -- would resolve "armor/miscellaneous" to whichever class
+                    -- happened to be built last.
+                    local byClass = cache.subclasses[cat.class]
+                    if not byClass then
+                        byClass = {}
+                        cache.subclasses[cat.class] = byClass
+                    end
+                    byClass[string.lower(sub.name)] = sub.subclass
+                end
+                si = si + 1
+            end
+        end
+        ci = ci + 1
+    end
+    return cache
+end
+
+function buy.Categories()
+    if not categoryCache then categoryCache = BuildCategoryCache() end
+    return categoryCache
+end
+
+-- The AH session teaches us these names; drop the cache when it ends so a
+-- different locale or a late-loading client can rebuild.
+function buy.ResetCategories()
+    categoryCache = nil
+end
+
+-- Equip slots for a given class/subclass, lazily per pair. GetAuctionInvTypes
+-- is guarded: it is not present on every 1.12 build, and a nil call here would
+-- take the whole parse down.
+local function SlotsFor(class, subclass)
+    local cache = buy.Categories()
+    local key = tostring(class or 0) .. ":" .. tostring(subclass or 0)
+    local found = cache.slots[key]
+    if found then return found end
+    found = {}
+    if GetAuctionInvTypes then
+        local ok, list = pcall(function()
+            return { GetAuctionInvTypes(class or 0, subclass or 0) }
+        end)
+        if ok and list then
+            local i = 1
+            while i <= table.getn(list) do
+                local globalKey = list[i]
+                local label = globalKey and getglobal(globalKey)
+                if label and label ~= "" then
+                    found[string.lower(label)] = i
+                end
+                i = i + 1
+            end
+        end
+    end
+    cache.slots[key] = found
+    return found
 end
 
 -- "20" or "20-30" (the VALUE half of a two-token "level/..." form) -> min, max.
@@ -264,6 +379,7 @@ function buy.ParseTerm(text)
         nameWords = {}, tooltipWords = {}, inTooltip = false,
         exact = false, usable = false, buyoutOnly = false, stackOnly = false,
         quality = nil, minLevel = nil, maxLevel = nil,
+        class = nil, subclass = nil, slot = nil,
     }
     local function appendWord(word)
         if term.inTooltip then
@@ -272,6 +388,8 @@ function buy.ParseTerm(text)
             table.insert(term.nameWords, word)
         end
     end
+
+    local cats = buy.Categories()
 
     local tokens = util.Split(text, "/")
     local i, n = 1, table.getn(tokens)
@@ -305,15 +423,30 @@ function buy.ParseTerm(text)
             else appendWord(raw) end
         else
             local q = ParseFusedQuality(tok)
+            local mn, mx
+            if not q then mn, mx = ParseFusedLevel(tok) end
             if q then
                 term.quality = q
+            elseif mn then
+                term.minLevel = mn; term.maxLevel = mx
+            -- Categories, in the order they can be resolved. A subclass only
+            -- means anything once its class is known, and a slot only once
+            -- both are -- which is why "armor/leather" works and
+            -- "leather/armor" leaves "leather" as name text. Never inside a
+            -- tooltip clause: after `tooltip` every word is search text, so
+            -- searching tooltips for the literal word "bag" still works.
+            elseif not term.inTooltip and not term.class
+                and cats.classes[tok] then
+                term.class = cats.classes[tok]
+            elseif not term.inTooltip and term.class and not term.subclass
+                and cats.subclasses[term.class]
+                and cats.subclasses[term.class][tok] then
+                term.subclass = cats.subclasses[term.class][tok]
+            elseif not term.inTooltip and term.class and not term.slot
+                and SlotsFor(term.class, term.subclass)[tok] then
+                term.slot = SlotsFor(term.class, term.subclass)[tok]
             else
-                local mn, mx = ParseFusedLevel(tok)
-                if mn then
-                    term.minLevel = mn; term.maxLevel = mx
-                else
-                    appendWord(raw)
-                end
+                appendWord(raw)
             end
         end
         i = i + 1
@@ -359,26 +492,40 @@ function buy.MaxStackFor(itemId, link)
     return nil
 end
 
--- A dedicated, never-shown tooltip used only to read an auction listing's
--- tooltip text for the "tooltip" post-filter. 1.12 has no NumLines(); the
--- stock technique (see CLAUDE.md rule 14) is getglobal on the template's
--- numbered FontStrings until one comes back empty.
-local queryTip = CreateFrame("GameTooltip", "AegisExchangeQueryTooltip", nil,
-    "GameTooltipTemplate")
-queryTip:SetOwner(UIParent, "ANCHOR_NONE")
+-- A dedicated, never-shown tooltip for reading an auction listing's tooltip
+-- text (the "tooltip" post-filter).
+--
+-- Built LAZILY and read exactly the way sell.lua's IsAuctionable does it,
+-- because that one demonstrably works on the real client and the first
+-- version of this one did not:
+--   * lazy, not file scope -- a templated frame built while core/buy.lua is
+--     still loading is not reliably ready;
+--   * SetOwner BEFORE ClearLines, then the Set* call (this order);
+--   * bounded by NumLines(). GameTooltipTemplate reuses its TextLeftN
+--     FontStrings, so they survive from whatever was shown last -- walking
+--     until GetText() comes back nil either stops early on line 1 or reads
+--     stale text from a previous, longer tooltip. NumLines() is the only
+--     honest bound.
+local function QueryTip()
+    if not buy._queryTip then
+        buy._queryTip = CreateFrame("GameTooltip", "AegisExchangeQueryTooltip",
+            nil, "GameTooltipTemplate")
+    end
+    return buy._queryTip
+end
 
 local function TooltipContainsAt(index, needleLower)
-    if not queryTip.SetAuctionItem then return false end
-    queryTip:ClearLines()
-    queryTip:SetOwner(UIParent, "ANCHOR_NONE")
-    queryTip:SetAuctionItem("list", index)
+    local tip = QueryTip()
+    if not tip.SetAuctionItem then return false end
+    tip:SetOwner(UIParent, "ANCHOR_NONE")
+    tip:ClearLines()
+    tip:SetAuctionItem("list", index)
+    local n = tip:NumLines() or 0
     local i = 1
-    while i <= 30 do
+    while i <= n do
         local fs = getglobal("AegisExchangeQueryTooltipTextLeft" .. i)
-        if not fs then break end
-        local text = fs:GetText()
-        if not text then break end
-        if string.find(string.lower(text), needleLower, 1, true) then
+        local text = fs and fs:GetText()
+        if text and string.find(string.lower(text), needleLower, 1, true) then
             return true
         end
         i = i + 1
@@ -397,6 +544,9 @@ function buy.CompileTerm(term)
         maxLevel = term.maxLevel and tostring(term.maxLevel) or "",
         isUsable = term.usable and true or nil,
         quality  = term.quality,
+        class    = term.class,
+        subclass = term.subclass,
+        invType  = term.slot,
     }
     local exactName = term.exact and string.lower(term.name or "") or nil
     local tooltipNeedle = term.tooltipText and string.lower(term.tooltipText)
@@ -412,8 +562,14 @@ function buy.CompileTerm(term)
             return false
         end
         if stackOnly then
+            -- Fails OPEN when the max stack is unknown. GetItemInfo only
+            -- answers for items in the client's cache, so on a cold cache
+            -- "not max" was true for every row and /stack returned an empty
+            -- page -- indistinguishable from "no full stacks exist", which is
+            -- exactly how it got reported as broken. Showing a few partial
+            -- stacks until the cache warms is the better failure.
             local max = buy.MaxStackFor(row.itemId, row.link)
-            if not max or row.count ~= max then return false end
+            if max and row.count ~= max then return false end
         end
         if tooltipNeedle and not TooltipContainsAt(row.index, tooltipNeedle) then
             return false
@@ -527,10 +683,11 @@ end
 local function SendQuery()
     local st = buy.state
     local b = st.terms[st.termIndex].blizz
-    -- name/minLevel/maxLevel as strings (see CLAUDE.md rule 9); index/flag
-    -- args (isUsable, quality) stay nil for "no filter".
-    QueryAuctionItems(b.name, b.minLevel, b.maxLevel, nil, nil, nil,
-        st.page, b.isUsable, b.quality)
+    -- name/minLevel/maxLevel as strings (see CLAUDE.md rule 9); the index and
+    -- flag args (invType, class, subclass, isUsable, quality) stay nil for
+    -- "no filter".
+    QueryAuctionItems(b.name, b.minLevel, b.maxLevel, b.invType, b.class,
+        b.subclass, st.page, b.isUsable, b.quality)
     st.phase   = "wait_results"
     st.timeout = buy.TIMEOUT
     Notify()
@@ -714,6 +871,9 @@ end)
 A.RegisterEvent("AUCTION_HOUSE_CLOSED", function()
     buy.state.phase = "idle"
     buy.driver:Hide()
+    -- The category names came from the session that just ended; drop them so
+    -- the next one rebuilds (they are only readable while the AH is open).
+    buy.ResetCategories()
 end)
 
 -- ---------------------------------------------------------------------------

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -539,33 +539,13 @@ function buy.ParseQuery(text)
     return terms
 end
 
--- Max stack size out of a GetItemInfo call, WITHOUT counting return slots.
---
--- The return list differs between clients:
---   vanilla 1.12   name, link, quality, minLevel, type, subType,
---                  stackCount, equipLoc, texture              (9 values)
---   later clients  ...insert itemLevel at position 4, pushing
---                  everything after it down one                (10 values)
---
--- So a fixed index reads stackCount on one client and equipLoc on the other.
--- That is what made `/stack` report "stack size unknown" for a stack of Silk
--- Cloth sitting in the player's own bags: reading slot 8 got equipLoc, which
--- is empty for a trade good -- and would have thrown outright on a piece of
--- gear, where equipLoc is a string like "INVTYPE_CHEST".
---
--- In BOTH layouts stackCount is the LAST NUMBER in the list -- everything
--- after it (equipLoc, texture) is a string. Find that instead of counting.
+-- Max stack size, via the shared util.ItemInfo normaliser (which is where the
+-- "GetItemInfo's slots move between clients" problem is solved once, for every
+-- caller -- see its comment).
 local function StackCountFromItemInfo(link)
-    if not link then return nil end
-    local r = { GetItemInfo(link) }
-    local i = table.getn(r)
-    while i >= 1 do
-        if type(r[i]) == "number" then
-            if r[i] > 0 then return r[i] end
-            return nil
-        end
-        i = i - 1
-    end
+    local info = util.ItemInfo(link)
+    local n = info and info.stackCount
+    if n and n > 0 then return n end
     return nil
 end
 buy.StackCountFromItemInfo = StackCountFromItemInfo

--- a/core/buy.lua
+++ b/core/buy.lua
@@ -398,6 +398,21 @@ local function ParseLevelValue(tok)
     return nil
 end
 
+-- "stack20" and "stack 20" -> 20, or nil.
+--
+-- The spaced form matters because tokens are split on "/", so typing
+-- "silk cloth/stack 20" hands the parser ONE token, "stack 20" -- it never
+-- reaches the two-token "stack" branch. Supporting all three spellings means
+-- the obvious thing to type works whichever way you reach for it.
+local function ParseFusedStack(tok)
+    local _, _, digits = string.find(tok, "^stack%s*(%d+)$")
+    if digits then
+        local n = tonumber(digits)
+        if n and n >= 1 then return n end
+    end
+    return nil
+end
+
 -- Fused "level20" / "level20-30" -> min, max, or nil.
 local function ParseFusedLevel(tok)
     local _, _, mn, mx = string.find(tok, "^level(%d+)%-(%d+)$")
@@ -414,6 +429,7 @@ function buy.ParseTerm(text)
     local term = {
         nameWords = {}, tooltipWords = {}, inTooltip = false,
         exact = false, usable = false, buyoutOnly = false, stackOnly = false,
+        stackSize = nil,
         quality = nil, minLevel = nil, maxLevel = nil,
         class = nil, subclass = nil, slot = nil,
     }
@@ -439,7 +455,16 @@ function buy.ParseTerm(text)
         elseif tok == "buyout" then
             term.buyoutOnly = true
         elseif tok == "stack" then
-            term.stackOnly = true
+            -- "stack/20" -- an EXPLICIT size. Needs no item data at all, which
+            -- is the whole point: it works on the first search, for any item,
+            -- however cold the client's cache is.
+            local nxt = tokens[i + 1]
+            local sz = nxt and tonumber(util.Trim(nxt))
+            if sz and sz >= 1 then
+                term.stackSize = math.floor(sz); i = i + 1
+            else
+                term.stackOnly = true
+            end
         elseif tok == "tooltip" then
             term.inTooltip = true
         elseif tok == "quality" then
@@ -459,10 +484,13 @@ function buy.ParseTerm(text)
             else appendWord(raw) end
         else
             local q = ParseFusedQuality(tok)
+            local sz = ParseFusedStack(tok)
             local mn, mx
-            if not q then mn, mx = ParseFusedLevel(tok) end
+            if not q and not sz then mn, mx = ParseFusedLevel(tok) end
             if q then
                 term.quality = q
+            elseif sz then
+                term.stackSize = sz
             elseif mn then
                 term.minLevel = mn; term.maxLevel = mx
             -- Categories, in the order they can be resolved. A subclass only
@@ -639,6 +667,7 @@ function buy.CompileTerm(term)
         or nil
     local buyoutOnly = term.buyoutOnly
     local stackOnly  = term.stackOnly
+    local stackSize  = term.stackSize
 
     local function filter(row, stats)
         if buyoutOnly and not (row.buyout and row.buyout > 0) then
@@ -647,12 +676,22 @@ function buy.CompileTerm(term)
         if exactName and string.lower(row.name or "") ~= exactName then
             return false
         end
-        if stackOnly then
-            -- An unknown max stack EXCLUDES the row -- "keep it just in case"
-            -- was worse: it let every partial stack through, so /stack looked
-            -- like it did nothing at all. But a silent exclusion looks equally
-            -- broken, so the count is reported and the caller surfaces it.
+        -- An EXPLICIT size needs no item data whatsoever -- just compare the
+        -- listing's own count. This is the reliable form.
+        if stackSize then
+            if row.count ~= stackSize then return false end
+        elseif stackOnly then
+            -- Bare `stack` means "full stacks", which needs the item's maximum
+            -- -- and GetItemInfo only knows that for items the client has
+            -- cached. Rather than dead-end on "unknown", fall back to the
+            -- largest count for that item ON THIS PAGE, which needs no item
+            -- data at all and is a fair reading of "the big stacks". The
+            -- caller is told which rule was used so the status line can say.
             local max = buy.MaxStackFor(row.itemId, row.link)
+            if not max then
+                max = stats and stats.pageMax and stats.pageMax[row.itemId]
+                if max and stats then stats.usedPageMax = true end
+            end
             if not max then
                 if stats then stats.unknownStack = (stats.unknownStack or 0) + 1 end
                 return false
@@ -861,7 +900,22 @@ function buy.ReadPage()
 
     -- A plain-text search (the common case) compiles to an always-true filter,
     -- so rows == rawRows and nothing about existing behaviour changes.
-    local stats = { unknownStack = 0 }
+    -- Largest count per item on this page, computed BEFORE filtering so bare
+    -- `stack` has something to fall back on when the client cannot tell us an
+    -- item's real maximum.
+    local pageMax = {}
+    local pi = 1
+    while pi <= table.getn(rawRows) do
+        local r = rawRows[pi]
+        if r.itemId and r.count then
+            if not pageMax[r.itemId] or r.count > pageMax[r.itemId] then
+                pageMax[r.itemId] = r.count
+            end
+        end
+        pi = pi + 1
+    end
+
+    local stats = { unknownStack = 0, pageMax = pageMax }
     local rows = {}
     local ri = 1
     while ri <= table.getn(rawRows) do

--- a/core/db.lua
+++ b/core/db.lua
@@ -582,24 +582,19 @@ function A.ReleaseMailScanning()
     return true
 end
 
--- Globals we also accept as proof a Courier is present, for the case where it
--- loads without calling ClaimMailScanning.
+-- The global we also accept as proof a Courier is present, for the case where
+-- it loads without calling ClaimMailScanning.
 --
--- PLACEHOLDER: Aegis: Courier has not named its addon global yet. Confirm the
--- real name once that repo settles it and trim this list -- the explicit claim
--- above is the contract, this is only a safety net.
-local COURIER_GLOBALS = { "AegisCourier", "Aegis_Courier" }
+-- Confirmed against Aegis: Courier's own core/init.lua, which declares
+-- `AegisCourier = {}`. NOT "Aegis_Courier" -- that is the addon folder and
+-- .toc name, and is never a global. The explicit claim above is the contract;
+-- this is only a safety net for a Courier that never got round to claiming.
+local COURIER_GLOBAL = "AegisCourier"
 
 -- Is something else responsible for reading the mailbox?
 function A.MailScanningExternal()
     if A.mailScanOwner then return true end
-    local i = 1
-    while i <= table.getn(COURIER_GLOBALS) do
-        local g = getglobal(COURIER_GLOBALS[i])
-        if type(g) == "table" then return true end
-        i = i + 1
-    end
-    return false
+    return type(getglobal(COURIER_GLOBAL)) == "table"
 end
 
 -- Income / spend / count over transactions at or after `sinceEpoch` (nil = all).

--- a/core/db.lua
+++ b/core/db.lua
@@ -92,6 +92,17 @@ local function DefaultAccountDB()
         -- Game constants, shared by every realm (see header note).
         vendors = {},   -- itemID   -> vendor sell price, per unit
         names   = {},   -- itemName -> itemID
+        -- Max stack size per item (20 for Mageweave, 10 for Copper Ore, ...).
+        -- Account-wide because it is a property of the ITEM, identical on
+        -- every realm -- same reasoning as vendor prices above.
+        --
+        -- Persisted because the only 1.12 source, GetItemInfo, answers ONLY
+        -- for items already in the client's local cache. An auction for
+        -- something you have never handled returns nil, so anything that asks
+        -- at browse time gets nil for exactly the items it most needs. We
+        -- learn opportunistically (bags, browsing, any successful lookup) and
+        -- keep it forever.
+        stacks  = {},   -- itemID   -> max stack size
         -- Shopping (Buy tab): saved lists + recent searches, account-wide so
         -- every character shares them.
         shopping = {
@@ -412,6 +423,21 @@ end
 function db.GetVendor(itemId)
     if not db.account or not db.account.vendors then return nil end
     return db.account.vendors[itemId]
+end
+
+-- Max stack size, learned opportunistically. See the `stacks` note in
+-- DefaultAccountDB for why this has to be persisted rather than asked for on
+-- demand.
+function db.SetMaxStack(itemId, count)
+    if not db.account or not itemId then return end
+    if not count or count < 1 then return end
+    if not db.account.stacks then db.account.stacks = {} end
+    db.account.stacks[itemId] = count
+end
+
+function db.GetMaxStack(itemId)
+    if not db.account or not db.account.stacks or not itemId then return nil end
+    return db.account.stacks[itemId]
 end
 
 -- Resolve an item name to an itemID (for tooltips with no link, e.g. the

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.5.0"
+A.version = "1.5.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.5.3"
+A.version = "1.6.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.5.2"
+A.version = "1.5.3"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.7.0"
+A.version = "1.8.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.6.0"
+A.version = "1.7.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.4.0"
+A.version = "1.5.0"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.5.1"
+A.version = "1.5.2"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/sell.lua
+++ b/core/sell.lua
@@ -592,8 +592,8 @@ function sell.IsAuctionable(bag, slot)
     return true
 end
 
--- Walk bags 0..4 and group every POSTABLE item by its category (GetItemInfo's
--- itemType). Soulbound / quest / conjured items are skipped. Returns an ordered
+-- Walk bags 0..4 and group every POSTABLE item by its category (util.ItemInfo's
+-- normalised itemType). Soulbound / quest / conjured items are skipped. Returns an ordered
 -- list of { name = className, items = { entry, ... } } where entry =
 -- { bag, slot, itemId, name, texture, count }. Order follows first appearance
 -- so the grouping is stable between refreshes.
@@ -608,7 +608,14 @@ function sell.ScanBags()
             local link = GetContainerItemLink(bag, slot)
             if link and sell.IsAuctionable(bag, slot) then
                 local texture, count = GetContainerItemInfo(bag, slot)
-                local iname, _, _, _, _, itype = GetItemInfo(link)
+                -- Through util.ItemInfo, NOT by indexing GetItemInfo: its
+                -- slots shift by one between vanilla 1.12 and later clients,
+                -- so the old `select 6` read the item's SUBTYPE ("Cloth") on
+                -- one and its TYPE ("Trade Goods") on the other -- meaning
+                -- these group headers silently differed by client.
+                local info = util.ItemInfo(link)
+                local iname = info and info.name
+                local itype = info and info.type
                 -- On 1.12 GetItemInfo may return nil until the client-side
                 -- item cache is warm. Fall back to the name between [...] in
                 -- the link so AH queries don't send a raw item-link string

--- a/core/util.lua
+++ b/core/util.lua
@@ -188,3 +188,60 @@ function util.CountKeys(t)
     end
     return n
 end
+
+-- ---------------------------------------------------------------------------
+-- GetItemInfo, normalised
+-- ---------------------------------------------------------------------------
+
+-- GetItemInfo's return LIST is not the same on every client:
+--
+--   vanilla 1.12   name link quality minLevel type subType
+--                  stackCount equipLoc texture                    (9 values)
+--   later clients  name link quality iLevel minLevel type subType
+--                  stackCount equipLoc texture                   (10 values)
+--
+-- itemLevel is inserted at position 4, so EVERY field after position 3 sits
+-- one slot further along on a later client. Indexing a fixed position is
+-- therefore wrong on one client or the other, silently: it reads the subtype
+-- where the type was meant, or the equip slot where the stack size was meant.
+-- Both of those shipped, and the second cost four rounds of "why does /stack
+-- do nothing".
+--
+-- Rather than detect the client (which we cannot do reliably, and which would
+-- be one more thing to get wrong), anchor on a field we can FIND: stackCount
+-- is the last NUMBER in the list, because everything after it is a string.
+-- Once its index is known, type / subType / minLevel are fixed offsets back
+-- from it, and equipLoc / texture fixed offsets forward. name / link / quality
+-- never move, so they are read absolutely.
+--
+-- Returns a named table, or nil when the client has no data for the item yet
+-- (which it often does not -- GetItemInfo only answers for cached items).
+function util.ItemInfo(link)
+    if not link then return nil end
+    local r = { GetItemInfo(link) }
+    local n = table.getn(r)
+    if n < 1 or not r[1] then return nil end
+
+    -- Index of the last number = stackCount.
+    local s = n
+    while s >= 1 and type(r[s]) ~= "number" do
+        s = s - 1
+    end
+    -- Nothing numeric at all means this is not a shape we understand; return
+    -- what is safe to read rather than guessing at the rest.
+    if s < 4 then
+        return { name = r[1], link = r[2], quality = r[3] }
+    end
+
+    return {
+        name       = r[1],
+        link       = r[2],
+        quality    = r[3],
+        minLevel   = r[s - 3],
+        type       = r[s - 2],
+        subType    = r[s - 1],
+        stackCount = r[s],
+        equipLoc   = r[s + 1],
+        texture    = r[s + 2],
+    }
+end

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -2348,11 +2348,21 @@ function ui.UpdateBuyList()
     local offset = FauxScrollFrame_GetOffset(ui.buyScroll)
 
     if A.buy then
-        local _, page, totalPages, totalAuctions, termIndex, totalTerms =
+        local _, page, totalPages, totalAuctions, termIndex, totalTerms, stats =
             A.buy.GetResults()
+        local unknown = stats and stats.unknownStack or 0
         if ui.buyResults then
             if table.getn(all) == 0 then
-                ui.buyStatus:SetText("No auctions found.")
+                if unknown > 0 then
+                    -- Never a bare "No auctions found" when a filter threw rows
+                    -- away for want of data: an unexplained empty page is
+                    -- indistinguishable from a broken filter, which is exactly
+                    -- how /stack got reported.
+                    ui.buyStatus:SetText("No full stacks \226\128\162 " .. unknown
+                        .. " skipped (stack size unknown \226\128\148 search again)")
+                else
+                    ui.buyStatus:SetText("No auctions found.")
+                end
             else
                 local order = dir == "asc" and "low to high" or "high to low"
                 local shown = ""
@@ -2367,6 +2377,10 @@ function ui.UpdateBuyList()
                 local headline = table.getn(all) .. " match(es)"
                 if table.getn(all) ~= totalAuctions then
                     headline = headline .. " (of " .. totalAuctions .. ")"
+                end
+                if unknown > 0 then
+                    shown = shown .. " \226\128\162 " .. unknown
+                        .. " skipped (stack size unknown)"
                 end
                 ui.buyStatus:SetText(headline .. " \226\128\162 "
                     .. sortKey .. " " .. order .. shown)

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1692,10 +1692,33 @@ function ui.FillResultRow(row, r)
         end
     end
     row.name:SetText(r.name)
-    if r.canUse == nil or r.canUse then
-        row.name:SetTextColor(C.text[1], C.text[2], C.text[3])
+    -- Colour the name by item QUALITY, the way its tooltip does -- a rare
+    -- reads blue, an epic purple. ITEM_QUALITY_COLORS is FrameXML's own table,
+    -- so the greens and blues match the rest of the game exactly rather than
+    -- being re-guessed here. Same treatment the Auctions tab already gives its
+    -- rows.
+    local q = r.quality
+    if q and ITEM_QUALITY_COLORS and ITEM_QUALITY_COLORS[q] then
+        local c = ITEM_QUALITY_COLORS[q]
+        row.name:SetTextColor(c.r, c.g, c.b)
     else
-        row.name:SetTextColor(0.9, 0.4, 0.4)
+        row.name:SetTextColor(C.text[1], C.text[2], C.text[3])
+    end
+    -- "You can't use this" used to be the name turning red, which quality
+    -- colouring now owns. It moves to a red tint on the ICON so the warning
+    -- survives -- the two cues were always fighting for the same pixels, and
+    -- the hover tooltip spells out the actual requirement either way.
+    --
+    -- The old test was `r.canUse == nil or r.canUse`, which never warned about
+    -- anything: GetAuctionItemInfo returns canUse as 1-or-NIL, so "nil" IS the
+    -- cannot-use answer, and treating it as unknown-so-assume-fine made the
+    -- red branch unreachable. Usable is simply "canUse is truthy".
+    if row.icon then
+        if r.canUse then
+            row.icon:SetVertexColor(1, 1, 1)
+        else
+            row.icon:SetVertexColor(1, 0.3, 0.3)
+        end
     end
     row.ct:SetText("x" .. r.count)
     row.unit:SetText(r.unit and util.FormatMoney(r.unit, true) or "\226\128\148")

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1932,6 +1932,7 @@ ui.GrowBuySideRows = function(n)
     box:SetAutoFocus(false)
     box:SetScript("OnEnterPressed", function() ui.DoBuySearch() end)
     box:SetScript("OnEscapePressed", function() box:ClearFocus() end)
+    box:SetScript("OnTabPressed", function() ui.BuyAutocomplete() end)
     ui.buyBox = box
 
     local maxLbl = panel:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
@@ -2244,6 +2245,30 @@ end
 
 -- ---- search + results --------------------------------------------------
 
+-- Cycle through autocomplete candidates for whatever's currently typed.
+-- Re-bases off the live text on the FIRST Tab press for a given prefix (so it
+-- always completes what you actually typed), then keeps cycling through the
+-- same candidate list on repeated presses without re-querying it each time.
+function ui.BuyAutocomplete()
+    if not ui.buyBox or not A.buy then return end
+    local cur = ui.buyBox:GetText() or ""
+    local ac = ui.buyAC
+    if not ac or cur ~= ac.current then
+        ac = { base = cur, candidates = A.buy.AutocompleteCandidates(cur),
+               index = 0 }
+        ui.buyAC = ac
+    end
+    local n = table.getn(ac.candidates)
+    if n == 0 then return end
+    ac.index = math.mod(ac.index, n) + 1
+    local pick = ac.candidates[ac.index]
+    ui.buyBox:SetText(pick)
+    ac.current = pick
+    if ui.buyBox.SetCursorPosition then
+        ui.buyBox:SetCursorPosition(string.len(pick))
+    end
+end
+
 function ui.DoBuySearch()
     if not ui.buyBox then return end
     ui.buyBox:ClearFocus()
@@ -2300,7 +2325,8 @@ function ui.UpdateBuyList()
     local offset = FauxScrollFrame_GetOffset(ui.buyScroll)
 
     if A.buy then
-        local _, page, totalPages, totalAuctions = A.buy.GetResults()
+        local _, page, totalPages, totalAuctions, termIndex, totalTerms =
+            A.buy.GetResults()
         if ui.buyResults then
             if table.getn(all) == 0 then
                 ui.buyStatus:SetText("No auctions found.")
@@ -2310,10 +2336,29 @@ function ui.UpdateBuyList()
                 if maxUnit and maxUnit > 0 then
                     shown = " \226\128\162 " .. total .. " under max"
                 end
-                ui.buyStatus:SetText(totalAuctions .. " auction(s) \226\128\162 "
+                -- `all` is already query-filtered (buyout-only, exact, tooltip
+                -- -- see buy.ReadPage's post-filter); totalAuctions is the raw
+                -- Blizzard count for this page's query, which can be bigger
+                -- once a filter is active. Showing both keeps the bigger
+                -- number from reading as "how many I can buy".
+                local headline = table.getn(all) .. " match(es)"
+                if table.getn(all) ~= totalAuctions then
+                    headline = headline .. " (of " .. totalAuctions .. ")"
+                end
+                ui.buyStatus:SetText(headline .. " \226\128\162 "
                     .. sortKey .. " " .. order .. shown)
             end
-            ui.buyPageText:SetText("Page " .. (page + 1) .. " / " .. totalPages)
+            local pageTxt = "Page " .. (page + 1) .. " / " .. totalPages
+            -- Multiple semicolon-separated OR terms browse as one combined
+            -- search (NextPage/PrevPage roll across term boundaries), so the
+            -- pager names which term you're currently on -- but only when
+            -- there's more than one, so the common single-term case looks
+            -- exactly as it always has.
+            if totalTerms and totalTerms > 1 then
+                pageTxt = "Term " .. termIndex .. "/" .. totalTerms
+                    .. "  \226\128\162  " .. pageTxt
+            end
+            ui.buyPageText:SetText(pageTxt)
         else
             ui.buyPageText:SetText("")
         end
@@ -5759,6 +5804,30 @@ function ui.TrySellFromBag(bag, slot)
     return true
 end
 
+-- Right-click a bag item while the BUY tab is up: search for it. Mirrors
+-- TrySellFromBag's shape but has no "auctionable" gate (you can shop for
+-- soulbound/conjured items even though you could never post them yourself).
+function ui.BuyRightClickActive()
+    return (ui.frame and ui.frame:IsVisible() and true or false)
+        and ui.selectedSubTab == "Buy"
+end
+
+function ui.TryBuySearchFromBag(bag, slot)
+    if not bag or not slot then return false end
+    if CursorHasItem and CursorHasItem() then return false end
+    local link = GetContainerItemLink(bag, slot)
+    if not link then return false end
+    local iname = GetItemInfo(link)
+    if not iname then
+        local _, _, n = string.find(link, "%[([^%]]+)%]")
+        iname = n
+    end
+    if not iname then return false end
+    if ui.buyBox then ui.buyBox:SetText(iname) end
+    ui.DoBuySearch()
+    return true
+end
+
 -- Save-and-replace (no secure hooks on 1.12) on BOTH right-click paths:
 --
 --   ContainerFrameItemButton_OnClick -- the stock bag buttons.
@@ -5767,21 +5836,33 @@ end
 --                                       UIs (pfUI, Stonkz's Bags, ...) work too.
 --
 -- The first hook returns without chaining when it handles the click, so the
--- second never double-fires for the stock bags.
+-- second never double-fires for the stock bags. Sell (place in slot) and Buy
+-- (search for it) are mutually exclusive by construction -- each Active()
+-- check requires its OWN sub-tab to be the visible one.
 function ui.HookBagRightClick()
     if ui.bagClickHooked then return end
     ui.bagClickHooked = true
 
+    local function tryHandle(bag, slot)
+        if ui.SellRightClickActive() and ui.TrySellFromBag(bag, slot) then
+            return true
+        end
+        if ui.BuyRightClickActive() and ui.TryBuySearchFromBag(bag, slot) then
+            return true
+        end
+        return false
+    end
+
     if ContainerFrameItemButton_OnClick then
         ui.orig_ContainerFrameItemButton_OnClick = ContainerFrameItemButton_OnClick
         ContainerFrameItemButton_OnClick = function(button, ignoreModifiers)
-            if button == "RightButton" and ui.SellRightClickActive() then
+            if button == "RightButton" then
                 -- `this` is the clicked item button; its parent carries the bag id.
                 local btn = this
                 local parent = btn and btn.GetParent and btn:GetParent() or nil
                 local bag = parent and parent.GetID and parent:GetID() or nil
                 local slot = btn and btn.GetID and btn:GetID() or nil
-                if ui.TrySellFromBag(bag, slot) then return end
+                if tryHandle(bag, slot) then return end
             end
             return ui.orig_ContainerFrameItemButton_OnClick(button, ignoreModifiers)
         end
@@ -5790,11 +5871,49 @@ function ui.HookBagRightClick()
     if UseContainerItem then
         ui.orig_UseContainerItem = UseContainerItem
         UseContainerItem = function(bag, slot, onSelf)
-            if ui.SellRightClickActive() and ui.TrySellFromBag(bag, slot) then
-                return
-            end
+            if tryHandle(bag, slot) then return end
             return ui.orig_UseContainerItem(bag, slot, onSelf)
         end
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- Shift-click an item to search for it on the Buy tab
+--
+-- The ROADMAP quick win is worded as "drag an inventory item onto the search
+-- box, or right-click an item link in chat". 1.12 has no generic way to ask
+-- "what item is on the cursor" for an arbitrary custom frame like our search
+-- box -- that only exists for API-blessed drop targets (the AH's own sell
+-- slot uses ClickAuctionSellItemButton precisely because of this gap). Assume
+-- the generic form does not exist, per CLAUDE.md.
+--
+-- What 1.12 DOES have, and is the standard vanilla idiom for exactly this
+-- interaction, is HandleModifiedItemClick(itemLink) -- the single global every
+-- shift-click on an item funnels through, whether the item is in a bag, a
+-- tooltip, an AH row, OR a chat link. Hooking it covers both halves of the
+-- ROADMAP bullet with one well-understood, save-and-replace-safe hook instead
+-- of two separate guesses at cursor APIs.
+function ui.HookItemShiftClick()
+    if ui.shiftClickHooked then return end
+    ui.shiftClickHooked = true
+    if not HandleModifiedItemClick then return end
+
+    ui.orig_HandleModifiedItemClick = HandleModifiedItemClick
+    HandleModifiedItemClick = function(link)
+        if ui.BuyRightClickActive() and IsShiftKeyDown and IsShiftKeyDown()
+            and link then
+            local name = GetItemInfo(link)
+            if not name then
+                local _, _, n = string.find(link, "%[([^%]]+)%]")
+                name = n
+            end
+            if name then
+                if ui.buyBox then ui.buyBox:SetText(name) end
+                ui.DoBuySearch()
+                return
+            end
+        end
+        return ui.orig_HandleModifiedItemClick(link)
     end
 end
 
@@ -5802,6 +5921,7 @@ function ui.OpenWindow()
     ui.BuildWindow()
     ui.HookAuctionFrame()
     ui.HookBagRightClick()
+    ui.HookItemShiftClick()
     ui.showBlizzard = false
     -- Synchronous hide is safe HERE: our AUCTION_HOUSE_SHOW handler runs
     -- after the client's AuctionFrame_Show() has already passed its

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1488,6 +1488,146 @@ MakeMoneyGSC = function(parent, onChange)
     return grp
 end
 
+-- A compact dropdown: a button showing the current choice, and a popup list.
+--
+-- Hand-built from Frame + Button for the same reason MakeHSlider is hand-built
+-- from Slider. UIDropDownMenuTemplate does exist on 1.12 -- aux uses it -- but
+-- it is a fiddly template with its own initialise-timing and width rules, and
+-- this file's standing policy is to build from primitives that always exist
+-- rather than inherit a template whose behaviour we have not verified here.
+--
+-- The popup is parented to the WINDOW, not to the row, so it draws above
+-- everything and is not clipped by whatever panel the dropdown sits in.
+local openDropdown
+local function MakeDropdown(parent, width, onSelect)
+    local dd = {}
+    dd.options = {}
+    dd.value = nil
+
+    local btn = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate")
+    btn:SetWidth(width)
+    btn:SetHeight(20)
+    btn:SetText("All")
+    dd.button = btn
+
+    local list = CreateFrame("Frame", nil, ui.frame)
+    list:SetFrameLevel(parent:GetFrameLevel() + 20)
+    list:SetBackdrop({
+        bgFile = "Interface\Tooltips\UI-Tooltip-Background",
+        edgeFile = "Interface\Tooltips\UI-Tooltip-Border",
+        tile = true, tileSize = 16, edgeSize = 12,
+        insets = { left = 3, right = 3, top = 3, bottom = 3 },
+    })
+    list:SetBackdropColor(C.well[1], C.well[2], C.well[3], 1)
+    list:SetBackdropBorderColor(C.border[1], C.border[2], C.border[3])
+    list:EnableMouse(true)     -- swallow clicks; don't fall through to the form
+    list:Hide()
+    dd.list = list
+    dd.rows = {}
+
+    local ROW_H = 15
+
+    function dd:Close()
+        list:Hide()
+        if openDropdown == dd then openDropdown = nil end
+    end
+
+    -- Label for the currently selected value, or "All" when nothing is set.
+    function dd:Repaint()
+        local text = "All"
+        local i = 1
+        while i <= table.getn(dd.options) do
+            if dd.options[i].value == dd.value then
+                text = dd.options[i].text
+                break
+            end
+            i = i + 1
+        end
+        ui.SetTextClipped(btn:GetFontString(), text, width - 8)
+    end
+
+    function dd:SetOptions(opts)
+        dd.options = opts or {}
+        -- A value that is no longer offered cannot stay selected -- this is
+        -- what clears Subclass when the Class above it changes.
+        local stillValid = (dd.value == nil)
+        local i = 1
+        while i <= table.getn(dd.options) do
+            if dd.options[i].value == dd.value then stillValid = true end
+            i = i + 1
+        end
+        if not stillValid then dd.value = nil end
+        dd:Repaint()
+    end
+
+    function dd:SetValue(v, silent)
+        dd.value = v
+        dd:Repaint()
+        if not silent and onSelect then onSelect(v) end
+    end
+
+    function dd:GetValue() return dd.value end
+
+    function dd:SetEnabled(on)
+        if on then btn:Enable() else btn:Disable(); dd:Close() end
+    end
+
+    function dd:Open()
+        if openDropdown and openDropdown ~= dd then openDropdown:Close() end
+        -- "All" plus one row per option; All clears the filter.
+        local entries = { { text = "All", value = nil } }
+        local i = 1
+        while i <= table.getn(dd.options) do
+            table.insert(entries, dd.options[i])
+            i = i + 1
+        end
+        local n = table.getn(entries)
+        list:SetWidth(width)
+        list:SetHeight(n * ROW_H + 8)
+        list:ClearAllPoints()
+        list:SetPoint("TOPLEFT", btn, "BOTTOMLEFT", 0, -2)
+
+        local r = 1
+        while r <= n do
+            local row = dd.rows[r]
+            if not row then
+                row = CreateFrame("Button", nil, list)
+                row:SetHeight(ROW_H)
+                row:SetPoint("TOPLEFT", list, "TOPLEFT", 4, -(4 + (r - 1) * ROW_H))
+                row:SetPoint("TOPRIGHT", list, "TOPRIGHT", -4, -(4 + (r - 1) * ROW_H))
+                row:SetHighlightTexture(
+                    "Interface\QuestFrame\UI-QuestTitleHighlight")
+                row.aegisNoSkin = true
+                local fs = row:CreateFontString(nil, "OVERLAY",
+                    "GameFontHighlightSmall")
+                fs:SetPoint("LEFT", row, "LEFT", 3, 0)
+                fs:SetJustifyH("LEFT")
+                row.label = fs
+                row:SetScript("OnClick", function()
+                    dd:SetValue(row.optValue)
+                    dd:Close()
+                end)
+                dd.rows[r] = row
+            end
+            row.optValue = entries[r].value
+            ui.SetTextClipped(row.label, entries[r].text, width - 12)
+            row:Show()
+            r = r + 1
+        end
+        while r <= table.getn(dd.rows) do dd.rows[r]:Hide(); r = r + 1 end
+
+        list:Show()
+        openDropdown = dd
+    end
+
+    btn:SetScript("OnClick", function()
+        if list:IsVisible() then dd:Close() else dd:Open() end
+    end)
+
+    dd:Repaint()
+    return dd
+end
+
 -- Horizontal slider, hand-built from the base Slider widget for the same reason
 -- as the Aegis tab's scroll bar: Slider is a primitive that always exists, so
 -- there's no "Couldn't find inherited node" risk from guessing a 1.12 template.
@@ -1980,6 +2120,31 @@ ui.GrowBuySideRows = function(n)
     addToList:SetText("Add to list")
     addToList:SetScript("OnClick", function() ui.BuyAddSearchToList() end)
 
+    -- View switcher. The ROADMAP wants Results / Saved Searches / Filter
+    -- Builder sharing this space rather than a fourth top-level sub-tab;
+    -- Saved Searches is 2c and slots in here without rework.
+    ui.buyViewBtns = {}
+    local views = { { "Results", "results" }, { "Builder", "builder" } }
+    local prevView = nil
+    local vi = 1
+    while vi <= table.getn(views) do
+        local v = views[vi]
+        local b = CreateFrame("Button", "AegisExchangeBuyView" .. v[2],
+            panel, "UIPanelButtonTemplate")
+        b:SetWidth(62); b:SetHeight(20)
+        if prevView then
+            b:SetPoint("LEFT", prevView, "RIGHT", 4, 0)
+        else
+            b:SetPoint("TOPLEFT", searchBtn, "TOPLEFT", 232, 0)
+        end
+        b:SetText(v[1])
+        b.view = v[2]
+        b:SetScript("OnClick", function() ui.SetBuyView(b.view) end)
+        ui.buyViewBtns[vi] = b
+        prevView = b
+        vi = vi + 1
+    end
+
     -- Pager.
     local nextBtn = CreateFrame("Button", "AegisExchangeBuyNextButton",
         panel, "UIPanelButtonTemplate")
@@ -2044,7 +2209,369 @@ ui.GrowBuyRows = function(n)
     end
     ui.GrowBuyRows(BUY_ROWS)
 
+    ui.BuildFilterBuilder(panel, rowLeft)
+    ui.SetBuyView("results")
+
     ui.RefreshBuySidebar()
+end
+
+-- ---------------------------------------------------------------------------
+-- Filter Builder (ROADMAP 2b)
+--
+-- Form-driven query construction: pick from dropdowns, get a valid query
+-- string. It occupies the same area as the results table and the two swap via
+-- ui.SetBuyView -- the ROADMAP calls for a row of switchable views (Results /
+-- Saved Searches / Filter Builder) reusing this space rather than adding a
+-- fourth top-level sub-tab. Saved Searches is 2c; the switcher is built to
+-- take a third entry without rework.
+--
+-- Every dropdown is populated from buy.Categories() / buy.SlotOptions(), which
+-- read the auction house's OWN localized names -- there is no second copy of
+-- the category list here to drift out of sync.
+-- ---------------------------------------------------------------------------
+
+function ui.SetBuyView(name)
+    ui.buyView = name
+    local builder = (name == "builder")
+    if ui.buyBuilder then
+        if builder then ui.buyBuilder:Show() else ui.buyBuilder:Hide() end
+    end
+    -- Everything belonging to the results view hides together.
+    local resultsBits = { ui.buyScroll, ui.buyPageText }
+    local i = 1
+    while i <= table.getn(resultsBits) do
+        local w = resultsBits[i]
+        if w then if builder then w:Hide() else w:Show() end end
+        i = i + 1
+    end
+    if ui.buyHeaders then
+        for _, h in pairs(ui.buyHeaders) do
+            if builder then h:Hide() else h:Show() end
+        end
+    end
+    local ri = 1
+    while ri <= table.getn(ui.buyRows or {}) do
+        if builder then ui.buyRows[ri]:Hide() end
+        ri = ri + 1
+    end
+    if ui.buyViewBtns then
+        local bi = 1
+        while bi <= table.getn(ui.buyViewBtns) do
+            local b = ui.buyViewBtns[bi]
+            if b.view == name then b:LockHighlight() else b:UnlockHighlight() end
+            bi = bi + 1
+        end
+    end
+    if not builder then ui.UpdateBuyList() end
+end
+
+function ui.BuildFilterBuilder(panel, rowLeft)
+    if ui.buyBuilder then return end
+
+    local f = CreateFrame("Frame", "AegisExchangeFilterBuilder", panel)
+    f:SetPoint("TOPLEFT", panel, "TOPLEFT", rowLeft, -70)
+    f:SetPoint("BOTTOMRIGHT", panel, "BOTTOMRIGHT", -12, 10)
+    f:Hide()
+    ui.buyBuilder = f
+
+    local function header(text, x, y)
+        local fs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+        fs:SetPoint("TOPLEFT", f, "TOPLEFT", x, y)
+        fs:SetText(text)
+        fs:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
+        return fs
+    end
+    local function label(text, x, y)
+        local fs = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+        fs:SetPoint("TOPLEFT", f, "TOPLEFT", x, y)
+        fs:SetWidth(58)
+        fs:SetJustifyH("RIGHT")
+        fs:SetText(text)
+        fs:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+        return fs
+    end
+    local function check(text, x, y, onClick)
+        local c = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
+        c:SetWidth(20); c:SetHeight(20)
+        c:SetPoint("TOPLEFT", f, "TOPLEFT", x, y)
+        local fs = c:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+        fs:SetPoint("LEFT", c, "RIGHT", 2, 0)
+        fs:SetText(text)
+        fs:SetTextColor(C.text[1], C.text[2], C.text[3])
+        c:SetScript("OnClick", function()
+            if onClick then onClick() end
+            ui.RefreshBuilder()
+        end)
+        return c
+    end
+
+    local LX, RXX = 0, 250        -- the form's two columns
+    local DDW = 116
+
+    -- ---- Blizzard-side filters ----------------------------------------
+    header("AUCTION HOUSE FILTER", LX, 0)
+
+    label("Name", LX, -22)
+    local nameBox = CreateFrame("EditBox", nil, f, "InputBoxTemplate")
+    nameBox:SetWidth(DDW); nameBox:SetHeight(18)
+    nameBox:SetPoint("TOPLEFT", f, "TOPLEFT", LX + 64, -19)
+    nameBox:SetAutoFocus(false)
+    nameBox:SetScript("OnEscapePressed", function() nameBox:ClearFocus() end)
+    nameBox:SetScript("OnEnterPressed", function()
+        nameBox:ClearFocus(); ui.RefreshBuilder()
+    end)
+    nameBox:SetScript("OnTextChanged", function() ui.RefreshBuilder() end)
+    ui.fbName = nameBox
+
+    ui.fbExact = check("Exact match", LX + 62, -42)
+
+    label("Level", LX, -70)
+    ui.fbMinLevel = MakeNumBox(f, 32, function() ui.RefreshBuilder() end)
+    ui.fbMinLevel:SetPoint("TOPLEFT", f, "TOPLEFT", LX + 64, -67)
+    local dash = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    dash:SetPoint("LEFT", ui.fbMinLevel, "RIGHT", 4, 0)
+    dash:SetText("\226\128\147")
+    dash:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+    ui.fbMaxLevel = MakeNumBox(f, 32, function() ui.RefreshBuilder() end)
+    ui.fbMaxLevel:SetPoint("LEFT", dash, "RIGHT", 4, 0)
+
+    label("Class", LX, -94)
+    ui.fbClass = MakeDropdown(f, DDW, function()
+        -- Class gates Subclass gates Slot: changing it invalidates both below.
+        ui.fbSubclass:SetValue(nil, true)
+        ui.fbSlot:SetValue(nil, true)
+        ui.RefreshBuilder()
+    end)
+    ui.fbClass.button:SetPoint("TOPLEFT", f, "TOPLEFT", LX + 64, -91)
+
+    label("Subclass", LX, -118)
+    ui.fbSubclass = MakeDropdown(f, DDW, function()
+        ui.fbSlot:SetValue(nil, true)
+        ui.RefreshBuilder()
+    end)
+    ui.fbSubclass.button:SetPoint("TOPLEFT", f, "TOPLEFT", LX + 64, -115)
+
+    label("Slot", LX, -142)
+    ui.fbSlot = MakeDropdown(f, DDW, function() ui.RefreshBuilder() end)
+    ui.fbSlot.button:SetPoint("TOPLEFT", f, "TOPLEFT", LX + 64, -139)
+
+    label("Quality", LX, -166)
+    ui.fbQuality = MakeDropdown(f, DDW, function() ui.RefreshBuilder() end)
+    ui.fbQuality.button:SetPoint("TOPLEFT", f, "TOPLEFT", LX + 64, -163)
+
+    ui.fbUsable = check("Usable by me", LX + 62, -186)
+
+    -- ---- Post-filters --------------------------------------------------
+    header("EXTRA FILTERS", RXX, 0)
+
+    ui.fbBuyout = check("Buyout only", RXX, -20)
+    ui.fbStack  = check("Full stacks only", RXX, -42)
+
+    local ssLbl = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    ssLbl:SetPoint("TOPLEFT", f, "TOPLEFT", RXX + 2, -70)
+    ssLbl:SetText("Stack size")
+    ssLbl:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+    ui.fbStackSize = MakeNumBox(f, 34, function() ui.RefreshBuilder() end)
+    ui.fbStackSize:SetPoint("LEFT", ssLbl, "RIGHT", 6, 0)
+    local ssNote = f:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    ssNote:SetPoint("TOPLEFT", f, "TOPLEFT", RXX + 2, -88)
+    ssNote:SetText("exact size; beats 'full stacks'")
+
+    local ttLbl = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    ttLbl:SetPoint("TOPLEFT", f, "TOPLEFT", RXX + 2, -114)
+    ttLbl:SetText("Tooltip contains")
+    ttLbl:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+    local ttBox = CreateFrame("EditBox", nil, f, "InputBoxTemplate")
+    ttBox:SetWidth(DDW); ttBox:SetHeight(18)
+    ttBox:SetPoint("TOPLEFT", f, "TOPLEFT", RXX + 4, -132)
+    ttBox:SetAutoFocus(false)
+    ttBox:SetScript("OnEscapePressed", function() ttBox:ClearFocus() end)
+    ttBox:SetScript("OnEnterPressed", function()
+        ttBox:ClearFocus(); ui.RefreshBuilder()
+    end)
+    ttBox:SetScript("OnTextChanged", function() ui.RefreshBuilder() end)
+    ui.fbTooltip = ttBox
+
+    -- ---- Preview + actions ---------------------------------------------
+    local pvLbl = f:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    pvLbl:SetPoint("TOPLEFT", f, "TOPLEFT", LX, -216)
+    pvLbl:SetText("Query")
+    pvLbl:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
+
+    ui.fbPreview = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    ui.fbPreview:SetPoint("TOPLEFT", f, "TOPLEFT", LX + 44, -216)
+    ui.fbPreview:SetJustifyH("LEFT")
+    ui.fbPreview:SetTextColor(C.amber[1], C.amber[2], C.amber[3])
+
+    ui.fbNote = f:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    ui.fbNote:SetPoint("TOPLEFT", f, "TOPLEFT", LX, -234)
+    ui.fbNote:SetJustifyH("LEFT")
+
+    local function action(text, w, prev, fn)
+        local b = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")
+        b:SetWidth(w); b:SetHeight(20)
+        if prev then b:SetPoint("LEFT", prev, "RIGHT", 5, 0)
+        else b:SetPoint("TOPLEFT", f, "TOPLEFT", LX, -258) end
+        b:SetText(text)
+        b:SetScript("OnClick", fn)
+        return b
+    end
+    local bSearch = action("Search", 62, nil, function() ui.BuilderSearch() end)
+    local bTo = action("To box", 62, bSearch, function() ui.BuilderExport() end)
+    local bOr = action("+ OR", 52, bTo, function() ui.BuilderExport(true) end)
+    local bFrom = action("From box", 70, bOr, function() ui.BuilderImport() end)
+    action("Clear", 52, bFrom, function() ui.BuilderClear() end)
+    ui.fbSearchBtn = bSearch
+
+    ui.BuilderClear()
+end
+
+
+-- ---- Filter Builder: form <-> term --------------------------------------
+
+-- Quality dropdown options, from the client's own localized names.
+local function BuilderQualityOptions()
+    local out = {}
+    local i = 0
+    while i <= 5 do
+        local desc = getglobal("ITEM_QUALITY" .. i .. "_DESC")
+        if desc and desc ~= "" then
+            table.insert(out, { value = i, text = desc })
+        end
+        i = i + 1
+    end
+    return out
+end
+
+-- Read the form into a parsed-term-shaped table -- the same shape
+-- buy.ParseTerm produces, so buy.TermToQuery and buy.TermsEqual both apply.
+function ui.BuilderTerm()
+    local function num(box)
+        local n = tonumber(util.Trim(box:GetText() or ""))
+        if n and n >= 1 then return math.floor(n) end
+        return nil
+    end
+    local minL, maxL = num(ui.fbMinLevel), num(ui.fbMaxLevel)
+    -- One end of a range alone still means a range; the parser stores both.
+    if minL and not maxL then maxL = minL end
+    if maxL and not minL then minL = maxL end
+
+    local tip = util.Trim(ui.fbTooltip:GetText() or "")
+    return {
+        name       = util.Trim(ui.fbName:GetText() or ""),
+        exact      = ui.fbExact:GetChecked() and true or false,
+        usable     = ui.fbUsable:GetChecked() and true or false,
+        buyoutOnly = ui.fbBuyout:GetChecked() and true or false,
+        stackOnly  = ui.fbStack:GetChecked() and true or false,
+        stackSize  = num(ui.fbStackSize),
+        quality    = ui.fbQuality:GetValue(),
+        minLevel   = minL,
+        maxLevel   = maxL,
+        class      = ui.fbClass:GetValue(),
+        subclass   = ui.fbSubclass:GetValue(),
+        slot       = ui.fbSlot:GetValue(),
+        tooltipText = (tip ~= "") and tip or nil,
+    }
+end
+
+-- Push a parsed term INTO the form. Dropdowns are set silently so filling the
+-- form doesn't fire the gating callbacks and immediately clear what we just
+-- set -- the gating is re-applied once, by RefreshBuilder, at the end.
+function ui.BuilderSetTerm(t)
+    t = t or {}
+    ui.fbName:SetText(t.name or "")
+    ui.fbExact:SetChecked(t.exact and 1 or nil)
+    ui.fbUsable:SetChecked(t.usable and 1 or nil)
+    ui.fbBuyout:SetChecked(t.buyoutOnly and 1 or nil)
+    ui.fbStack:SetChecked(t.stackOnly and 1 or nil)
+    ui.fbStackSize:SetText(t.stackSize and tostring(t.stackSize) or "")
+    ui.fbMinLevel:SetText(t.minLevel and tostring(t.minLevel) or "")
+    ui.fbMaxLevel:SetText(t.maxLevel and tostring(t.maxLevel) or "")
+    ui.fbTooltip:SetText(t.tooltipText or "")
+
+    ui.fbClass:SetOptions(A.buy.ClassOptions())
+    ui.fbClass:SetValue(t.class, true)
+    ui.fbSubclass:SetOptions(A.buy.SubclassOptions(t.class))
+    ui.fbSubclass:SetValue(t.subclass, true)
+    ui.fbSlot:SetOptions(A.buy.SlotOptions(t.class, t.subclass))
+    ui.fbSlot:SetValue(t.slot, true)
+    ui.fbQuality:SetOptions(BuilderQualityOptions())
+    ui.fbQuality:SetValue(t.quality, true)
+
+    ui.RefreshBuilder()
+end
+
+function ui.BuilderClear()
+    ui.BuilderSetTerm(nil)
+    if ui.fbNote then ui.fbNote:SetText("") end
+end
+
+-- Re-apply the class -> subclass -> slot gating, then repaint the preview.
+function ui.RefreshBuilder()
+    if not ui.buyBuilder or ui.builderPainting then return end
+    -- SetOptions can clear a now-invalid value, which would re-enter here.
+    ui.builderPainting = true
+
+    local class = ui.fbClass:GetValue()
+    ui.fbSubclass:SetOptions(A.buy.SubclassOptions(class))
+    ui.fbSubclass:SetEnabled(class ~= nil)
+    local subclass = ui.fbSubclass:GetValue()
+    ui.fbSlot:SetOptions(A.buy.SlotOptions(class, subclass))
+    ui.fbSlot:SetEnabled(class ~= nil
+        and table.getn(A.buy.SlotOptions(class, subclass)) > 0)
+
+    local term = ui.BuilderTerm()
+    local q = A.buy.TermToQuery(term)
+    ui.fbPreview:SetText(q ~= "" and q or "(everything)")
+    if ui.fbSearchBtn then ui.fbSearchBtn:Enable() end
+
+    ui.builderPainting = false
+end
+
+function ui.BuilderSearch()
+    local q = A.buy.TermToQuery(ui.BuilderTerm())
+    if ui.buyBox then ui.buyBox:SetText(q) end
+    ui.SetBuyView("results")
+    ui.DoBuySearch()
+end
+
+-- Put the built query into the search box. `orTerm` appends it as another
+-- semicolon term instead of replacing -- the builder edits ONE term, and this
+-- is how you assemble a multi-term query out of it.
+function ui.BuilderExport(orTerm)
+    local q = A.buy.TermToQuery(ui.BuilderTerm())
+    if not ui.buyBox then return end
+    local cur = util.Trim(ui.buyBox:GetText() or "")
+    if orTerm and cur ~= "" and q ~= "" then
+        ui.buyBox:SetText(cur .. ";" .. q)
+        ui.fbNote:SetText("Appended as another OR term.")
+    else
+        ui.buyBox:SetText(q)
+        ui.fbNote:SetText("Copied to the search box.")
+    end
+    ui.fbNote:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+end
+
+-- Load the search box back into the form.
+--
+-- The builder edits ONE term, so a multi-term query loads its FIRST term and
+-- SAYS so. Silently dropping the rest would be the worst option: you would
+-- edit what looked like your query and export something narrower.
+function ui.BuilderImport()
+    if not ui.buyBox then return end
+    local text = util.Trim(ui.buyBox:GetText() or "")
+    local terms = A.buy.ParseQuery(text)
+    ui.BuilderSetTerm(terms[1])
+    local n = table.getn(terms)
+    if n > 1 then
+        ui.fbNote:SetText("Loaded term 1 of " .. n
+            .. " \226\128\148 the other " .. (n - 1)
+            .. " are not shown here, and 'To box' will replace them.")
+        ui.fbNote:SetTextColor(0.9, 0.6, 0.3)
+    else
+        ui.fbNote:SetText("Loaded from the search box.")
+        ui.fbNote:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
+    end
 end
 
 -- ---- sidebar model + paint ---------------------------------------------
@@ -2295,6 +2822,9 @@ end
 function ui.DoBuySearch()
     if not ui.buyBox then return end
     ui.buyBox:ClearFocus()
+    -- Any search shows its results. Running one while the form is up and
+    -- leaving the form covering the answer would be its own small bug.
+    if ui.buyView == "builder" then ui.SetBuyView("results") end
     if not A.buy then
         ui.buyStatus:SetText("Buy engine not loaded \226\128\148 fully restart WoW.")
         return
@@ -2325,7 +2855,13 @@ end
 function ui.RefreshBuy()
     if not ui.buyBuilt then return end
     ui.RefreshBuySidebar()
-    ui.UpdateBuyList()
+    if ui.buyView == "builder" then
+        -- The builder owns this space right now; repainting the results list
+        -- would un-hide its rows over the top of the form.
+        ui.RefreshBuilder()
+    else
+        ui.UpdateBuyList()
+    end
 end
 
 function ui.UpdateBuyList()

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -1511,13 +1511,26 @@ local function MakeDropdown(parent, width, onSelect)
     dd.button = btn
 
     local list = CreateFrame("Frame", nil, ui.frame)
+    -- The popup must cover EVERYTHING in the window, so it gets its own
+    -- strata rather than a frame-level bid inside the panel's -- the same
+    -- move Blizzard's own DropDownList makes. Level alone lost to the form's
+    -- edit boxes.
+    list:SetFrameStrata("FULLSCREEN_DIALOG")
     list:SetFrameLevel(parent:GetFrameLevel() + 20)
+    -- DOUBLED backslashes, and this file has three tests pinning them: in Lua
+    -- source "\T" is not an escape, so a single backslash silently vanishes
+    -- and the client gets "InterfaceTooltips..." -- a texture that does not
+    -- exist. SetBackdrop draws nothing for a bad path, which shipped as a
+    -- see-through popup with the form bleeding through the option text.
     list:SetBackdrop({
-        bgFile = "Interface\Tooltips\UI-Tooltip-Background",
-        edgeFile = "Interface\Tooltips\UI-Tooltip-Border",
+        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
         tile = true, tileSize = 16, edgeSize = 12,
         insets = { left = 3, right = 3, top = 3, bottom = 3 },
     })
+    -- Fully opaque. The default tooltip backdrop color is translucent by
+    -- design (tooltips hover over the world); a menu you read options from
+    -- is not a tooltip.
     list:SetBackdropColor(C.well[1], C.well[2], C.well[3], 1)
     list:SetBackdropBorderColor(C.border[1], C.border[2], C.border[3])
     list:EnableMouse(true)     -- swallow clicks; don't fall through to the form
@@ -1596,7 +1609,7 @@ local function MakeDropdown(parent, width, onSelect)
                 row:SetPoint("TOPLEFT", list, "TOPLEFT", 4, -(4 + (r - 1) * ROW_H))
                 row:SetPoint("TOPRIGHT", list, "TOPRIGHT", -4, -(4 + (r - 1) * ROW_H))
                 row:SetHighlightTexture(
-                    "Interface\QuestFrame\UI-QuestTitleHighlight")
+                    "Interface\\QuestFrame\\UI-QuestTitleHighlight")
                 row.aegisNoSkin = true
                 local fs = row:CreateFontString(nil, "OVERLAY",
                     "GameFontHighlightSmall")
@@ -2006,11 +2019,25 @@ function ui.BuildBuyTab()
     ui.buyBuilt = true
     ui.buyExpanded = {}
 
-    -- ===== Left: shopping-list sidebar ==================================
-    local sideHdr = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    sideHdr:SetPoint("TOPLEFT", panel, "TOPLEFT", 10, -10)
-    sideHdr:SetText("Shopping Lists")
-    sideHdr:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
+    -- ===== Left: category tree OR shopping-list sidebar (ROADMAP 2e) ====
+    -- Two modes share this column. "Categories" is the Blizzard-style browse
+    -- tree -- click your way to Weapons > Two-Handed Swords without typing a
+    -- query. "Advanced" is the original Shopping Lists sidebar (lists +
+    -- recent searches). ui.SetBuyLeft switches them; the choice persists per
+    -- character.
+    local catModeBtn = CreateFrame("Button", "AegisExchangeBuyLeftCats",
+        panel, "UIPanelButtonTemplate")
+    catModeBtn:SetWidth(78); catModeBtn:SetHeight(18)
+    catModeBtn:SetPoint("TOPLEFT", panel, "TOPLEFT", 10, -6)
+    catModeBtn:SetText("Categories")
+    catModeBtn:SetScript("OnClick", function() ui.SetBuyLeft("cats") end)
+    local advModeBtn = CreateFrame("Button", "AegisExchangeBuyLeftAdv",
+        panel, "UIPanelButtonTemplate")
+    advModeBtn:SetWidth(76); advModeBtn:SetHeight(18)
+    advModeBtn:SetPoint("LEFT", catModeBtn, "RIGHT", 4, 0)
+    advModeBtn:SetText("Advanced")
+    advModeBtn:SetScript("OnClick", function() ui.SetBuyLeft("adv") end)
+    ui.buyLeftBtns = { cats = catModeBtn, adv = advModeBtn }
 
     local sideScroll = CreateFrame("ScrollFrame", "AegisExchangeBuySideScroll",
         panel, "FauxScrollFrameTemplate")
@@ -2044,10 +2071,24 @@ ui.GrowBuySideRows = function(n)
             row.ex = ex
             local lbl = row:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
             lbl:SetPoint("LEFT", row, "LEFT", 14, 0)
-            lbl:SetWidth(SIDE_W - 16)
+            -- NO SetWidth here. A constrained FontString WRAPS long text onto
+            -- a second line on 1.12 (SetTextClipped's comment), and these rows
+            -- are 18px tall -- a wrapped recent-search query painted itself
+            -- across the row below. The paint clips with SetTextClipped
+            -- instead.
             lbl:SetJustifyH("LEFT")
             row.label = lbl
             row:SetScript("OnClick", function() ui.OnBuySideClick(row.entry) end)
+            -- A clipped entry is unreadable without the full text somewhere:
+            -- long queries are exactly the rows that get cut.
+            row:SetScript("OnEnter", function()
+                if row.full then
+                    GameTooltip:SetOwner(row, "ANCHOR_RIGHT")
+                    GameTooltip:SetText(row.full, 1, 1, 1)
+                    GameTooltip:Show()
+                end
+            end)
+            row:SetScript("OnLeave", function() GameTooltip:Hide() end)
             row:Hide()
             ui.buySideRows[i] = row
             i = i + 1
@@ -2084,6 +2125,52 @@ ui.GrowBuySideRows = function(n)
     listSearchBtn:SetText("Search entire list")
     listSearchBtn:SetScript("OnClick", function() ui.BuySearchList() end)
     ui.buyListSearchBtn = listSearchBtn
+
+    -- Everything that exists only in Advanced mode, so SetBuyLeft can swap
+    -- the whole column in one loop. Sidebar ROWS are not here: their paint
+    -- (UpdateBuySidebar) shows them again, so it is mode-guarded instead.
+    ui.buyAdvBits = { sideScroll, addBtn, renBtn, delBtn, listSearchBtn }
+
+    -- ===== Left, mode 2: the category tree (ROADMAP 2e) =================
+    local catScroll = CreateFrame("ScrollFrame", "AegisExchangeBuyCatScroll",
+        panel, "FauxScrollFrameTemplate")
+    catScroll:SetPoint("TOPLEFT", panel, "TOPLEFT", 10, -28)
+    catScroll:SetPoint("BOTTOMLEFT", panel, "BOTTOMLEFT", 10, 20)
+    catScroll:SetWidth(SIDE_W)
+    catScroll:SetScript("OnVerticalScroll", function()
+        FauxScrollFrame_OnVerticalScroll(SIDE_ROW_H, ui.UpdateCatTree)
+    end)
+    catScroll:Hide()
+    ui.buyCatScroll = catScroll
+
+    ui.buyCatRows = {}
+    ui.buyCatExpanded = {}
+    ui.GrowCatRows = function(n)
+        if n > SIDE_ROWS_MAX then n = SIDE_ROWS_MAX end
+        local i = table.getn(ui.buyCatRows) + 1
+        while i <= n do
+            local row = CreateFrame("Button", nil, panel)
+            row:SetHeight(SIDE_ROW_H)
+            row:SetWidth(SIDE_W)
+            if i == 1 then
+                row:SetPoint("TOPLEFT", catScroll, "TOPLEFT", 0, 0)
+            else
+                row:SetPoint("TOPLEFT", ui.buyCatRows[i - 1], "BOTTOMLEFT", 0, 0)
+            end
+            local lbl = row:CreateFontString(nil, "OVERLAY",
+                "GameFontHighlightSmall")
+            lbl:SetPoint("LEFT", row, "LEFT", 4, 0)
+            -- No width constraint; the paint clips (same rule as the
+            -- sidebar rows and for the same wrap-onto-the-next-row reason).
+            lbl:SetJustifyH("LEFT")
+            row.label = lbl
+            row:SetScript("OnClick", function() ui.OnCatClick(row.entry) end)
+            row:Hide()
+            ui.buyCatRows[i] = row
+            i = i + 1
+        end
+    end
+    ui.GrowCatRows(SIDE_ROWS)
 
     -- ===== Right: filter row + results ==================================
     local RX = SIDE_W + 24    -- right-column origin
@@ -2164,6 +2251,10 @@ ui.GrowBuySideRows = function(n)
     prevBtn:SetPoint("RIGHT", ui.buyPageText, "LEFT", -6, 0)
     prevBtn:SetText("<")
     prevBtn:SetScript("OnClick", function() if A.buy then A.buy.PrevPage() end end)
+    -- Kept on ui so SetBuyView can hide the pager with the rest of the
+    -- results view -- paging results you cannot see still queries the server.
+    ui.buyPrevBtn = prevBtn
+    ui.buyNextBtn = nextBtn
 
     ui.buyStatus = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
     ui.buyStatus:SetPoint("TOPLEFT", searchBtn, "BOTTOMLEFT", 0, -8)
@@ -2212,7 +2303,12 @@ ui.GrowBuyRows = function(n)
     ui.BuildFilterBuilder(panel, rowLeft)
     ui.SetBuyView("results")
 
-    ui.RefreshBuySidebar()
+    -- Left-column mode: restore the per-character choice; the tree is the
+    -- default for a fresh character (2e: Blizzard-style browsing out of the
+    -- box, with Advanced one click away).
+    local saved = A.db and A.db.char and A.db.char.ui
+        and A.db.char.ui.buyLeft
+    ui.SetBuyLeft(saved == "adv" and "adv" or "cats")
 end
 
 -- ---------------------------------------------------------------------------
@@ -2236,8 +2332,13 @@ function ui.SetBuyView(name)
     if ui.buyBuilder then
         if builder then ui.buyBuilder:Show() else ui.buyBuilder:Hide() end
     end
-    -- Everything belonging to the results view hides together.
-    local resultsBits = { ui.buyScroll, ui.buyPageText }
+    -- Everything belonging to the results view hides together. buyStatus is
+    -- in the list because it paints at the same height as the form's first
+    -- header -- "7 match(es) ..." showing through "AUCTION HOUSE FILTER" was
+    -- a reported bug. The pager goes with it: its buttons still worked while
+    -- invisible results were underneath, so a stray click queried the server.
+    local resultsBits = { ui.buyScroll, ui.buyPageText, ui.buyStatus,
+                          ui.buyPrevBtn, ui.buyNextBtn }
     local i = 1
     while i <= table.getn(resultsBits) do
         local w = resultsBits[i]
@@ -2609,12 +2710,16 @@ end
 
 function ui.RefreshBuySidebar()
     if not ui.buySideScroll then return end
+    -- In Categories mode this column belongs to the tree; painting here
+    -- would Show() sidebar rows straight over it.
+    if ui.buyLeft == "cats" then return end
     ui.FlattenShopping()
     ui.UpdateBuySidebar()
 end
 
 function ui.UpdateBuySidebar()
     if not ui.buySideScroll then return end
+    if ui.buyLeft == "cats" then return end
     local flat = ui.buyFlat or {}
     local vis = ui.RowsFor(ui.buySideScroll, SIDE_ROW_H, SIDE_ROWS, SIDE_ROWS_MAX)
     ui.GrowBuySideRows(vis)
@@ -2628,27 +2733,40 @@ function ui.UpdateBuySidebar()
         if e then
             row.entry = e
             row.ex:SetText("")
+            -- Clip, never wrap: the label has no width constraint (see
+            -- GrowBuySideRows), so a long query must be cut here or it runs
+            -- over the scrollbar and the rows beside it. When it IS cut,
+            -- remember the full text for the row's hover tooltip.
+            local LW = SIDE_W - 18
+            local function put(text, full)
+                ui.SetTextClipped(row.label, text, LW)
+                if row.label:GetText() ~= text then
+                    row.full = full or text
+                else
+                    row.full = nil
+                end
+            end
             if e.kind == "hdr" then
-                row.label:SetText(e.text)
+                put(e.text)
                 row.label:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
             elseif e.kind == "list" then
                 row.ex:SetText(ui.buyExpanded[e.index] and "-" or "+")
                 local mark = ""
                 if ui.buySelList == e.index then mark = "> " end
-                row.label:SetText(mark .. e.name)
+                put(mark .. e.name, e.name)
                 if ui.buySelList == e.index then
                     row.label:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
                 else
                     row.label:SetTextColor(C.text[1], C.text[2], C.text[3])
                 end
             elseif e.kind == "item" then
-                row.label:SetText("  " .. e.name)
+                put("  " .. e.name, e.name)
                 row.label:SetTextColor(C.goldDim[1], C.goldDim[2], C.goldDim[3])
             elseif e.kind == "recent" then
-                row.label:SetText(e.name)
+                put(e.name)
                 row.label:SetTextColor(C.text[1], C.text[2], C.text[3])
             else
-                row.label:SetText("  " .. (e.text or ""))
+                put("  " .. (e.text or ""), e.text)
                 row.label:SetTextColor(0.5, 0.5, 0.5)
             end
             row:Show()
@@ -2673,6 +2791,197 @@ function ui.OnBuySideClick(e)
         ui.buyBox:SetText(e.name)
         ui.DoBuySearch()
     end
+end
+
+-- ---- category tree (ROADMAP 2e) ----------------------------------------
+
+-- Switch the left column between the category tree ("cats") and the
+-- Shopping Lists sidebar ("adv"), remembering the choice per character.
+function ui.SetBuyLeft(mode)
+    if mode ~= "adv" then mode = "cats" end
+    ui.buyLeft = mode
+    if A.db and A.db.char then
+        A.db.char.ui = A.db.char.ui or {}
+        A.db.char.ui.buyLeft = mode
+    end
+
+    local adv = (mode == "adv")
+    local i = 1
+    while i <= table.getn(ui.buyAdvBits or {}) do
+        local w = ui.buyAdvBits[i]
+        if w then if adv then w:Show() else w:Hide() end end
+        i = i + 1
+    end
+    local ri = 1
+    while ri <= table.getn(ui.buySideRows or {}) do
+        if not adv then ui.buySideRows[ri]:Hide() end
+        ri = ri + 1
+    end
+    if ui.buyCatScroll then
+        if adv then ui.buyCatScroll:Hide() else ui.buyCatScroll:Show() end
+    end
+    ri = 1
+    while ri <= table.getn(ui.buyCatRows or {}) do
+        if adv then ui.buyCatRows[ri]:Hide() end
+        ri = ri + 1
+    end
+    if ui.buyLeftBtns then
+        if adv then
+            ui.buyLeftBtns.adv:LockHighlight()
+            ui.buyLeftBtns.cats:UnlockHighlight()
+        else
+            ui.buyLeftBtns.cats:LockHighlight()
+            ui.buyLeftBtns.adv:UnlockHighlight()
+        end
+    end
+
+    if adv then ui.RefreshBuySidebar() else ui.RefreshCatTree() end
+end
+
+-- Flatten the class > subclass > slot hierarchy into visible rows, honouring
+-- what is expanded. Everything comes from buy.ClassOptions / SubclassOptions
+-- / SlotOptions -- the same three calls the Filter Builder's dropdowns use,
+-- which read the client's own localized names. No category list lives here.
+function ui.FlattenCats()
+    local flat = { { kind = "all", name = "All Categories" } }
+    local classes = A.buy and A.buy.ClassOptions() or {}
+    local ci = 1
+    while ci <= table.getn(classes) do
+        local c = classes[ci]
+        local cx = ui.buyCatExpanded[c.value] and true or false
+        table.insert(flat, { kind = "class", class = c.value,
+            name = c.text, expanded = cx })
+        if cx then
+            local subs = A.buy.SubclassOptions(c.value)
+            local si = 1
+            while si <= table.getn(subs) do
+                local s = subs[si]
+                local skey = c.value .. ":" .. s.value
+                local slots = A.buy.SlotOptions(c.value, s.value)
+                local canX = table.getn(slots) > 0
+                local sx = (canX and ui.buyCatExpanded[skey]) and true or false
+                table.insert(flat, { kind = "sub", class = c.value,
+                    subclass = s.value, name = s.text,
+                    expandable = canX, expanded = sx })
+                if sx then
+                    local li = 1
+                    while li <= table.getn(slots) do
+                        table.insert(flat, { kind = "slot", class = c.value,
+                            subclass = s.value, slot = slots[li].value,
+                            name = slots[li].text })
+                        li = li + 1
+                    end
+                end
+                si = si + 1
+            end
+        end
+        ci = ci + 1
+    end
+    ui.buyCatFlat = flat
+end
+
+function ui.RefreshCatTree()
+    if not ui.buyCatScroll or ui.buyLeft ~= "cats" then return end
+    ui.FlattenCats()
+    ui.UpdateCatTree()
+end
+
+function ui.UpdateCatTree()
+    if not ui.buyCatScroll or ui.buyLeft ~= "cats" then return end
+    local flat = ui.buyCatFlat or {}
+    local vis = ui.RowsFor(ui.buyCatScroll, SIDE_ROW_H, SIDE_ROWS, SIDE_ROWS_MAX)
+    ui.GrowCatRows(vis)
+    ui.SkinNewRows(ui.buyCatRows)
+    FauxScrollFrame_Update(ui.buyCatScroll, table.getn(flat), vis, SIDE_ROW_H)
+    local offset = FauxScrollFrame_GetOffset(ui.buyCatScroll)
+    local i = 1
+    while i <= table.getn(ui.buyCatRows) do
+        local row = ui.buyCatRows[i]
+        local e = (i <= vis) and flat[i + offset] or nil
+        if e then
+            row.entry = e
+            -- The +/- fold glyph and the depth indent live in the label
+            -- text itself: one FontString per row keeps the rows cheap.
+            local text
+            if e.kind == "all" then
+                text = e.name
+            elseif e.kind == "class" then
+                text = (e.expanded and "- " or "+ ") .. e.name
+            elseif e.kind == "sub" then
+                if e.expandable then
+                    text = "   " .. (e.expanded and "- " or "+ ") .. e.name
+                else
+                    text = "   " .. e.name
+                end
+            else
+                text = "      " .. e.name
+            end
+            ui.SetTextClipped(row.label, text, SIDE_W - 8)
+            local key = ui.CatKey(e)
+            if key == ui.buyCatSel then
+                row.label:SetTextColor(C.gold[1], C.gold[2], C.gold[3])
+            else
+                row.label:SetTextColor(C.text[1], C.text[2], C.text[3])
+            end
+            row:Show()
+        else
+            row.entry = nil
+            row:Hide()
+        end
+        i = i + 1
+    end
+end
+
+-- Identity of a tree node, for selection highlighting.
+function ui.CatKey(e)
+    if not e or e.kind == "all" then return "all" end
+    if e.kind == "class" then return "c" .. e.class end
+    if e.kind == "sub" then return "c" .. e.class .. ":" .. e.subclass end
+    return "c" .. e.class .. ":" .. e.subclass .. ":" .. e.slot
+end
+
+function ui.OnCatClick(e)
+    if not e then return end
+    if e.kind == "class" then
+        ui.buyCatExpanded[e.class] = not ui.buyCatExpanded[e.class]
+        ui.CatApply(e.class, nil, nil)
+    elseif e.kind == "sub" then
+        if e.expandable then
+            local skey = e.class .. ":" .. e.subclass
+            ui.buyCatExpanded[skey] = not ui.buyCatExpanded[skey]
+        end
+        ui.CatApply(e.class, e.subclass, nil)
+    elseif e.kind == "slot" then
+        ui.CatApply(e.class, e.subclass, e.slot)
+    else
+        ui.CatApply(nil, nil, nil)
+    end
+    ui.buyCatSel = ui.CatKey(e)
+    ui.RefreshCatTree()
+end
+
+-- Feed a tree pick into the SAME engine the query box uses: rewrite the
+-- box's first term with the picked class/subclass/slot and search. Name
+-- text, quality, stack, tooltip -- every other filter the user already has
+-- in the box -- survives, because the term is parsed, modified and
+-- regenerated rather than replaced. Additional semicolon terms are
+-- regenerated untouched; TermToQuery round-trips by value, so this loses
+-- nothing.
+function ui.CatApply(class, subclass, slot)
+    if not (ui.buyBox and A.buy) then return end
+    local terms = A.buy.ParseQuery(util.Trim(ui.buyBox:GetText() or ""))
+    if table.getn(terms) == 0 then terms = { {} } end
+    terms[1].class = class
+    terms[1].subclass = subclass
+    terms[1].slot = slot
+    local parts = {}
+    local i = 1
+    while i <= table.getn(terms) do
+        table.insert(parts, A.buy.TermToQuery(terms[i]))
+        i = i + 1
+    end
+    ui.buyBox:SetText(table.concat(parts, ";"))
+    ui.DoBuySearch()
 end
 
 -- ---- list management (via a name-entry popup) --------------------------
@@ -2854,7 +3163,11 @@ end
 
 function ui.RefreshBuy()
     if not ui.buyBuilt then return end
-    ui.RefreshBuySidebar()
+    if ui.buyLeft == "cats" then
+        ui.RefreshCatTree()
+    else
+        ui.RefreshBuySidebar()
+    end
     if ui.buyView == "builder" then
         -- The builder owns this space right now; repainting the results list
         -- would un-hide its rows over the top of the form.
@@ -2897,6 +3210,19 @@ function ui.UpdateBuyList()
                     -- how /stack got reported.
                     ui.buyStatus:SetText("No full stacks \226\128\162 " .. unknown
                         .. " skipped (stack size unknown \226\128\148 search again)")
+                elseif totalAuctions and totalAuctions > 0 then
+                    -- The server DID match auctions; the post-filter (exact,
+                    -- stack size, buyout, tooltip) removed every one on this
+                    -- page. Same rule as above: an emptied page must say a
+                    -- filter emptied it -- a bare "No auctions found" here
+                    -- reads as a broken filter, and hides that another page
+                    -- may still hold matches.
+                    local t = "0 match(es) (of " .. totalAuctions .. ") \226\128\162 "
+                        .. "filters removed this page's rows"
+                    if totalPages and totalPages > 1 then
+                        t = t .. " \226\128\162 try the next page"
+                    end
+                    ui.buyStatus:SetText(t)
                 else
                     ui.buyStatus:SetText("No auctions found.")
                 end

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -2352,6 +2352,7 @@ function ui.UpdateBuyList()
             A.buy.GetResults()
         local unknown = stats and stats.unknownStack or 0
         if ui.buyResults then
+            local usedPageMax = stats and stats.usedPageMax
             if table.getn(all) == 0 then
                 if unknown > 0 then
                     -- Never a bare "No auctions found" when a filter threw rows
@@ -2377,6 +2378,13 @@ function ui.UpdateBuyList()
                 local headline = table.getn(all) .. " match(es)"
                 if table.getn(all) ~= totalAuctions then
                     headline = headline .. " (of " .. totalAuctions .. ")"
+                end
+                if usedPageMax then
+                    -- Say which rule produced these rows: "biggest on this
+                    -- page" is not the same promise as "a full stack", and
+                    -- quietly swapping one for the other would be worse than
+                    -- the dead end it replaced.
+                    shown = shown .. " \226\128\162 biggest on this page"
                 end
                 if unknown > 0 then
                     shown = shown .. " \226\128\162 " .. unknown

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -5836,7 +5836,12 @@ function ui.TrySellFromBag(bag, slot)
     local itemId = util.ItemIdFromLink(link)
     if not itemId then return false end
     local texture, count = GetContainerItemInfo(bag, slot)
-    local iname = GetItemInfo(link)
+    -- Via util.ItemInfo like every other caller. The NAME is position 1 and
+    -- never moved between client layouts, so this is uniformity rather than a
+    -- fix -- but it stops a second return being bolted on here later and
+    -- quietly reintroducing the shift.
+    local info = util.ItemInfo(link)
+    local iname = info and info.name
     if not iname then
         -- Same cold-item-cache fallback sell.ScanBags uses.
         local _, _, n = string.find(link, "%[([^%]]+)%]")
@@ -5862,7 +5867,12 @@ function ui.TryBuySearchFromBag(bag, slot)
     if CursorHasItem and CursorHasItem() then return false end
     local link = GetContainerItemLink(bag, slot)
     if not link then return false end
-    local iname = GetItemInfo(link)
+    -- Via util.ItemInfo like every other caller. The NAME is position 1 and
+    -- never moved between client layouts, so this is uniformity rather than a
+    -- fix -- but it stops a second return being bolted on here later and
+    -- quietly reintroducing the shift.
+    local info = util.ItemInfo(link)
+    local iname = info and info.name
     if not iname then
         local _, _, n = string.find(link, "%[([^%]]+)%]")
         iname = n
@@ -5947,7 +5957,8 @@ function ui.HookItemShiftClick()
     HandleModifiedItemClick = function(link)
         if ui.BuyRightClickActive() and IsShiftKeyDown and IsShiftKeyDown()
             and link then
-            local name = GetItemInfo(link)
+            local shiftInfo = util.ItemInfo(link)
+            local name = shiftInfo and shiftInfo.name
             if not name then
                 local _, _, n = string.find(link, "%[([^%]]+)%]")
                 name = n


### PR DESCRIPTION
Parser, compiler, core primitives, and the quick wins bundled with them.

**Nothing about casual usage changes.** A bare word with no recognised keyword is just name text — which is what it has always been — so typing an item name searches by name exactly as before. A plain search compiles to an always-true post-filter, making the common path byte-for-byte the old behaviour.

## The language

| Query | Effect |
|---|---|
| `linen cloth/exact` | only *Linen Cloth*, not *Bolt of Linen Cloth* |
| `belt/quality3`, `belt/quality/rare` | server-side quality |
| `sword/level20-30`, `sword/level/25` | server-side level range |
| `belt/usable` | server-side usable-by-me flag |
| `runecloth/buyout` | exclude bid-only auctions |
| `mageweave/stack` | fully-stacked listings only |
| `container/bag/tooltip/8` | name *container bag*, tooltip contains *8* |
| `linen;wool;silk` | three searches browsed as **one** list |

The grammar is aux's (settled in ROADMAP.md) — an original implementation of that shape, never ported code.

`buy.CompileTerm` returns `{ blizz, filter }`: the parts the 1.12 server can do become one 9-arg `QueryAuctionItems` (strings for name/levels per CLAUDE.md rule 9; index/flag args nil for "no filter"), and the parts it can't become a closure run over each row as `buy.ReadPage` loads the page — which already read one page at a time, so the filter slots into the existing loop rather than changing the browsing model.

**An unrecognised token can never break a query** — it falls back to literal name text. `quality/of/mercy` searches for "quality of mercy".

Semicolon terms browse as one list: `NextPage` past the last page of a term rolls into the next. `PrevPage` crossing backwards lands on the previous term's *first* page — we don't know its page count until we query it, and a round trip purely to deep-link "its last page" isn't worth the complexity. Documented at the function.

## Quick wins

- **Right-click a bag item on the Buy tab** to search for it. The Sell tab's right-click-to-slot is untouched — each fires only on its own tab, and both fall through to the default handler everywhere else.
- **Shift-click any item** — bag slot, chat link, tooltip — to search for it.
- **Tab-completion** from every item name Aegis has learned (scans, searches, browsing) plus recent searches. Press again to cycle.

### One interpretation call worth flagging

The ROADMAP asked for *"dragging an inventory item onto the search box or right-clicking an item link in chat"*. 1.12 has no generic "what item is on the cursor" for an arbitrary custom frame — that only exists for API-blessed drop targets, which is exactly why the AH's own sell slot needs `ClickAuctionSellItemButton`. Per CLAUDE.md I assumed the generic form doesn't exist.

What 1.12 *does* have is `HandleModifiedItemClick` — the single global every shift-click on an item funnels through, whether it's in a bag, a tooltip, or a chat link. One well-understood save-and-replace hook covers both halves of the bullet instead of two separate guesses at cursor APIs.

## Also fixed

`core/buy.lua` was folding every browsed listing into the price DB — but `core/scan.lua`'s `RecordVisiblePage` already does that for **every** result page anyone looks at, from the same event, with identical values. The duplicate is gone.

Found by a sabotage: I fed the DB from the *filtered* rows instead of the raw ones and the suite stayed green, because scan.lua had already recorded every row regardless. Verified the removal is safe by disabling scan.lua's passive feed — an existing test fails (`passive min unit buyout 200, got nil`), so the coverage is real and lives in the right place.

The consequence is worth stating either way, and is tested: **a filtered search narrows what is displayed, never what is learned.**

## Testing

`luac5.1 -p` clean; the simulated 1.12 harness passes. Compliance-checked the diff for `string.match`/`gmatch`, `#`, `%`, `table.setn`, secure hooks, and `select()` — clean.

New coverage: the full grammar (every keyword, both fused and two-token forms, the ROADMAP's `container/bag/tooltip/8` vs `container/bag/8` case, unparseable-token fallback), compiled Blizzard args, each post-filter in isolation, and end-to-end engine behaviour including term-boundary paging and the pager label.

Two harness gaps closed first: `GameTooltip:SetAuctionItem` now populates `TextLeftN` from a fixture (the tooltip filter was untestable without it), and `HandleModifiedItemClick` exists as a recording stub.

Sabotages run, each reverting one property:

| sabotage | caught by |
|---|---|
| `exact` compares raw, not lowercased | `exact keeps a literal match` |
| buyout-only filter inverted | `buyout filter keeps a real buyout` |
| `NextPage` never crosses a term boundary | `NextPage past the last page of term 1 queries term 2` |
| `PrevPage` never crosses back | `PrevPage crossing back queries term 1's page 0` |
| stack-only accepts any count | `stack-only keeps just the fully-stacked (20/20) listing` |
| tooltip filter always true | `tooltip filter keeps only the listing whose tooltip mentions 'dragon'` |
| scan.lua's passive price feed disabled | `passive min unit buyout 200, got nil` |

A real bug the tests caught before it shipped: `local mn, mx = nxt and ParseLevelValue(...)` silently drops the second return whenever `and` truncates to one value, so `level/20-30` parsed a min with no max. Noted in the ROADMAP as a hazard.

## ROADMAP

2a marked done, with two notes for later phases: `class`/`subclass`/`slot` keywords are deliberately **not** in this slice (they need index maps that 2b's Filter Builder must build anyway for its dropdowns — build once, share), and this slice's post-filters are an implicit AND, with `CompileTerm`'s single `filter` closure as the seam 2d's `and`/`or`/`not` should compose into.

Not a **restart** release — no new `.lua` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L)_