### PR TITLE
Fix the multi-second freeze: a scan callback that outlived its scan

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.51.0
+## Version: 1.51.1
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.51.1]
+
+### Fixed
+- **The multi-second freeze.** Reported as a hang a few seconds after opening
+  the auction house, worse the longer a session ran, gone after a `/reload` —
+  and separately as a hang when posting a first auction. Same cause.
+  - Aegis feeds its price database from **every** auction page anyone looks at,
+    so browsing fills it in as you play. That is deliberate. But the same call
+    also handed the page to whichever **scan** was collecting — and it sat above
+    the check for whether the scanner was expecting a page at all.
+  - A finished scan never released its collector either. So one Sell-tab price
+    lookup left a collector armed for the rest of the session, receiving every
+    page from every source — a Buy search, the stock auction house, a manual
+    browse — and appending matching rows to a table nothing ever emptied. One
+    report showed **910 rows cached for a single item in a category holding 60
+    auctions**.
+  - It compounded, which is why it got worse over a session: reading that item
+    from cache handed back the cached table **by reference**, so the stray
+    appends then rewrote the cache itself, and that survived for the full
+    hour-long cache lifetime.
+  - Sorting, copying and grouping that table is what took seconds — on the path
+    the Sell tab runs whenever it repaints, including right after a post.
+  - Three fixes, because two of them are each enough on their own and neither
+    covers the third: a scan's collector now only receives pages that scan
+    asked for; a run releases its collector when it ends or is stopped; and the
+    listings cache is copied on the way out as well as on the way in.
+  - **The passive price feed is untouched** — browsing still fills the
+    database. A fix that switched that off would have been the worse bug:
+    silent, and visible only as prices that never appear.
+- Removed the temporary `Aegis cache store:` line that was printing to chat on
+  every price lookup.
+
+---
+
 ## [1.51.0]
 
 ### Added
@@ -3847,6 +3881,7 @@ that was there before moved behind one **Advanced** button. `/reload`.
 [1.25.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.24.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.23.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
+[1.51.1]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.51.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.50.3]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.50.2]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.51.0)
+# Aegis: Exchange (v1.51.1)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -511,7 +511,7 @@ and the reasons behind them, most of which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.51.0`) — quote it.
+1. Check the **version** in the window's title bar (`v1.51.1`) — quote it.
 2. **`/aex diag <shift-click an item>`** prints everything Aegis knows about
    that item and every step it took: which modules loaded, what the client
    returned, the item level and where it came from, and the disenchant value.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2390,6 +2390,64 @@ Worth noting what the mock hid again: `UnitFactionGroup` ignored its argument
 and always answered "Alliance", so a neutral auctioneer could not be modelled
 at all -- and the addon ignored that case for exactly as long.
 
+### The scan callback leak — v1.51.1
+
+A player reported a multi-second freeze; a second player traced it far enough
+to hand over a `/aex debug` log showing **910 rows cached for one item in a
+category holding 60 auctions**, and named the accumulation. Their proposed
+cause — `sell.listings` not cleared at scan start — was wrong; it IS cleared,
+one line above `A.scan.Start`. **The observation was right and the diagnosis
+was not**, which is the most useful kind of bug report and worth saying so.
+
+The real path has three links, and the first is a HARD RULE 16 violation
+hiding behind a gate that looked like it covered the file:
+
+```lua
+RecordVisiblePage(numOnPage)          -- ran on EVERY list update
+local st = scan.state
+if st.phase ~= "wait_results" then return end
+```
+
+`RecordVisiblePage` feeds the price DB from every page anyone looks at, which
+is deliberate and valuable. It also invoked the running scan's `onListing`,
+and it sat ABOVE the phase gate. Second link: `Finish()` set `phase = "idle"`
+but never cleared `st.callbacks`. So one Sell-tab price lookup left its
+collector armed for the rest of the session, receiving every page from every
+source and appending to a table nothing emptied.
+
+Third link is what made it compound rather than merely grow: `ScanItem`'s
+cache-hit path did `sell.listings = entry.listings`, aliasing the cached array,
+so the stray appends rewrote the cache — and that survived `CACHE_TTL`, an
+hour. **`ui/frame.lua` already documented this hazard in two places** and
+worked around it by rendering straight from the cache; the workaround was
+right, the alias it was avoiding was never removed.
+
+Sorting, copying and grouping that table is the seconds, on the path the Sell
+tab runs on every repaint — including the one after a post, which is why it
+also presented as "freezes when I post my first auction".
+
+**Three fixes, and the redundancy is the point.** A scan's collector only
+receives pages that scan asked for; a run releases its collector on Finish and
+on Stop; the cache is copied out as well as in. Two of those independently
+prevent the reported symptom — which is exactly why one sabotage
+(`scan-callback-not-scoped`) went unnoticed at first: with the callbacks
+cleared at Finish, removing the gate no longer leaked on a FINISHED scan.
+
+That escape found the case the suite was missing, and it is the case that
+matters most in the field: **a scan is live but not waiting for results for
+most of its life.** Between pages it sits in `wait_query` behind the throttle;
+it sits in `paused` for as long as a player has walked away from the
+auctioneer. Its callbacks are legitimately armed the whole time, so a page
+landing in those windows — browsing during a batch bag scan, the stock AH —
+is somebody else's page arriving at an armed collector. Nothing but the gate
+covers that.
+
+**And the fix had a way to go too far**, which is sabotaged too
+(`scan-passive-feed-gated-too`): gating the whole call rather than just the
+callback would stop the price DB filling in while you browse. That would be a
+worse bug than the freeze — silent, with no symptom but prices that never
+appear.
+
 ### Cancel All — v1.51.0
 
 Asked for directly. The interesting part is not the button, it is that

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.51.0"
+A.version = "1.51.1"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/core/scan.lua
+++ b/core/scan.lua
@@ -132,9 +132,20 @@ end
 -- to collect every listing of one item), it is invoked for EACH auction on the
 -- page as onListing(itemId, name, count, buyout, minBid, owner) — including
 -- bid-only ones, so the listings table can show them too.
-local function RecordVisiblePage(numOnPage)
+-- `ours` SEPARATES THE TWO JOBS, and mixing them up is what froze clients.
+-- Feeding the price DB from any page anyone looks at is deliberate. Handing
+-- that page to a SCAN's callback is not: the callback belongs to one run
+-- collecting one item, and a page the run did not ask for is somebody else's
+-- page -- a Buy-tab search, the stock auction house, a manual browse.
+--
+-- Before this, every list update in the session was delivered to whichever
+-- onListing was installed last, for as long as the client stayed up. The Sell
+-- tab's collector went on appending rows for its item and nothing ever emptied
+-- it, so sorting and copying that table came to take seconds. See the note
+-- above sell.ScanItem.
+local function RecordVisiblePage(numOnPage, ours)
     local st = scan.state
-    local onListing = st.callbacks and st.callbacks.onListing
+    local onListing = ours and st.callbacks and st.callbacks.onListing
     local tally = st.tally
     for i = 1, numOnPage do
         local name, _, count, quality, _, _, minBid, _, buyoutPrice, _, _, owner =
@@ -304,9 +315,15 @@ local function Finish()
     end
     st.phase = "idle"
     scan.driver:Hide()
-    if st.callbacks and st.callbacks.onComplete then
-        st.callbacks.onComplete(stats)
-    end
+    -- Take the callbacks OFF the state before running onComplete, and leave
+    -- nothing armed behind. Belt and braces against the freeze above: a
+    -- callback that outlives its run is a landmine either way. Cleared first
+    -- rather than after, because onComplete may start the next scan -- the
+    -- batch bag scan does -- and clearing afterwards would wipe the NEW run's
+    -- callbacks instead of the finished one's.
+    local cb = st.callbacks
+    st.callbacks = nil
+    if cb and cb.onComplete then cb.onComplete(stats) end
 end
 
 -- Begin the current category (queries[queryIndex]) at page 0.
@@ -330,10 +347,12 @@ end
 function scan.OnListUpdate()
     local numOnPage, totalAuctions = GetNumAuctionItems("list")
 
-    -- Passive feed: every result page anyone looks at updates the DB.
-    RecordVisiblePage(numOnPage)
-
+    -- Passive feed: every result page anyone looks at updates the DB. The
+    -- second argument says whether this page is one WE asked for, and is read
+    -- BEFORE the gate below, because the gate advances the state machine.
     local st = scan.state
+    RecordVisiblePage(numOnPage, st.phase == "wait_results")
+
     if st.phase ~= "wait_results" then return end
 
     -- This is the page we asked for: accept it and advance.
@@ -447,6 +466,8 @@ function scan.Stop()
     st.phase = "idle"
     st.lastCompleted = -1
     st.page = 0
+    -- Same reason as Finish: an abandoned run must not go on collecting.
+    st.callbacks = nil
     scan.driver:Hide()
 end
 

--- a/core/sell.lua
+++ b/core/sell.lua
@@ -716,6 +716,36 @@ function sell.StopBatchScan()
     sell.batchCurrentItemId = nil
 end
 
+-- A shallow copy of a listings array, row tables included.
+--
+-- ONE WRITER, because the cache has to be copied on the way IN and on the way
+-- OUT and only one of those was ever done. `sell.listings` is a live table
+-- that a running scan appends to; handing out the cached array by reference
+-- meant an append landed in the cache, and the corruption then survived for
+-- CACHE_TTL -- an hour of a Sell tab quietly getting slower, which is exactly
+-- how this presented in the field ("worse the longer the session runs, fine
+-- after a /reload").
+--
+-- ui/frame.lua already worked around this in two places by rendering straight
+-- from the cache and never touching sell.listings. Those comments describe
+-- this bug; the fix belongs here, where the alias was created.
+function sell.CopyListings(rows)
+    local out, i = {}, 1
+    while i <= table.getn(rows or {}) do
+        local r = rows[i]
+        out[i] = {
+            count  = r.count,
+            buyout = r.buyout,
+            unit   = r.unit,
+            minBid = r.minBid,
+            owner  = r.owner,
+            isMine = r.isMine,
+        }
+        i = i + 1
+    end
+    return out
+end
+
 -- Lowest per-unit buyout among the last scan's listings. `excludeMine` skips
 -- your own auctions (so undercut targets other sellers). Returns nil if none.
 function sell.LowestListingUnit(excludeMine)
@@ -741,7 +771,9 @@ function sell.ScanItem(itemName, itemId, onProgress, onDone)
     -- Cache hit: return stored results without a new scan.
     local entry = sell.cache[itemId]
     if entry and time() - entry.when < sell.CACHE_TTL then
-        sell.listings   = entry.listings
+        -- A COPY. Aliasing the cached array here is what let a stray append
+        -- rewrite the cache itself -- see sell.CopyListings.
+        sell.listings   = sell.CopyListings(entry.listings)
         sell.scanItemId = itemId
         sell.scanName   = itemName
         sell.scanWhen   = entry.when
@@ -777,31 +809,12 @@ function sell.ScanItem(itemName, itemId, onProgress, onDone)
                 return au < bu
             end)
             sell.scanWhen = time()
-            -- Store a deep copy in the cache so later mutations to sell.listings
-            -- don't corrupt the cached data.
-            local copy = {}
-            local li = 1
-            while li <= table.getn(sell.listings) do
-                local r = sell.listings[li]
-                table.insert(copy, {
-                    count  = r.count,
-                    buyout = r.buyout,
-                    unit   = r.unit,
-                    minBid = r.minBid,
-                    owner  = r.owner,
-                    isMine = r.isMine,
-                })
-                li = li + 1
-            end
-            sell.cache[itemId] = { listings = copy, when = sell.scanWhen }
-            -- Temporary debug: log what's being cached so we can trace
-            -- the root cause of cache entries with 0 rows.
-            if DEFAULT_CHAT_FRAME then
-                DEFAULT_CHAT_FRAME:AddMessage(
-                    "|cff5fc8f8Aegis cache store:|r "
-                    .. tostring(itemName) .. " (id:" .. tostring(itemId)
-                    .. ") rows=" .. tostring(table.getn(copy)))
-            end
+            -- Store a copy so later mutations to sell.listings cannot reach
+            -- the cached data. The read side copies too; see sell.CopyListings.
+            sell.cache[itemId] = {
+                listings = sell.CopyListings(sell.listings),
+                when     = sell.scanWhen,
+            }
             if onDone then onDone(sell.listings) end
         end,
     })

--- a/tests/README.md
+++ b/tests/README.md
@@ -153,6 +153,10 @@ tests/
     vendorbuy_test.lua      what a merchant CHARGES (unlimited stock beats a
                             cheaper limited one), and the two measured deposit
                             corrections
+    scan_leak_test.lua      the callback leak behind the multi-second freeze:
+                            a finished scan stops collecting, a live one takes
+                            only its own pages, and the price DB still fills
+                            from anything you browse
     external_buttons_test.lua  the buttons Aegis puts on Blizzard's windows:
                             the recorded anchor, and the pfUI nudge that moves
                             each one once and in the right direction

--- a/tests/sabotage.py
+++ b/tests/sabotage.py
@@ -2007,6 +2007,72 @@ end
      "        rec[meanKey] = value",
      "vendorbuy"),
 
+    # ---- the scan callback leak (the multi-second freeze) -----------------
+    # The gate removed, which is the bug exactly as it shipped: every page
+    # anyone looks at is handed to whichever scan callback was installed last,
+    # for the rest of the session. Nothing errors -- the Sell tab just gets
+    # slower until it hangs.
+    ("scan-callback-not-scoped", "core/scan.lua",
+     "    local onListing = ours and st.callbacks and st.callbacks.onListing",
+     "    local onListing = st.callbacks and st.callbacks.onListing",
+     "scan.leak"),
+
+    # The phase read AFTER the gate has advanced the state machine, so a page
+    # we DID ask for is judged by the state it left behind rather than the one
+    # it arrived in.
+    ("scan-ours-read-too-late", "core/scan.lua",
+     "    RecordVisiblePage(numOnPage, st.phase == \"wait_results\")",
+     "    RecordVisiblePage(numOnPage, false)",
+     "scan.leak"),
+
+    # A finished run leaves its callbacks armed -- the second half of the leak,
+    # and on its own enough to bring it back.
+    ("scan-finish-keeps-callbacks", "core/scan.lua",
+     """    local cb = st.callbacks
+    st.callbacks = nil
+    if cb and cb.onComplete then cb.onComplete(stats) end""",
+     """    if st.callbacks and st.callbacks.onComplete then
+        st.callbacks.onComplete(stats)
+    end""",
+     "scan.leak"),
+
+    # An abandoned run keeps collecting.
+    ("scan-stop-keeps-callbacks", "core/scan.lua",
+     """    -- Same reason as Finish: an abandoned run must not go on collecting.
+    st.callbacks = nil
+""",
+     "",
+     "scan.leak"),
+
+    # The passive price feed switched off along with the callback. This is the
+    # fix going too far, and it is the WORSE bug: silent, and visible only as
+    # prices that never fill in while you browse.
+    ("scan-passive-feed-gated-too", "core/scan.lua",
+     "    RecordVisiblePage(numOnPage, st.phase == \"wait_results\")",
+     "    if st.phase == \"wait_results\" then RecordVisiblePage(numOnPage, true) end",
+     "scan.leak"),
+
+    # The cache handed out by reference again, so a stray append rewrites it
+    # and the corruption outlives the scan by an hour.
+    ("sell-cache-hit-aliases", "core/sell.lua",
+     "        sell.listings   = sell.CopyListings(entry.listings)",
+     "        sell.listings   = entry.listings",
+     "scan.leak"),
+
+    # The copy made shallow at the ROW level: the array is new, every row is
+    # shared, so editing one reaches into the cache.
+    ("sell-copy-shares-rows", "core/sell.lua",
+     """        out[i] = {
+            count  = r.count,
+            buyout = r.buyout,
+            unit   = r.unit,
+            minBid = r.minBid,
+            owner  = r.owner,
+            isMine = r.isMine,
+        }""",
+     "        out[i] = r",
+     "scan.leak"),
+
     # ---- cancel all -------------------------------------------------------
     # The cancel order flipped. Cancelling shifts every later index down, so an
     # upward pass takes every other auction and reports success for all of
@@ -2171,6 +2237,7 @@ SUITES = {
     "disenchant.learn": "tests/units/disenchant_learn_test.lua",
     "clientdata": "tests/units/clientdata_test.lua",
     "vendorbuy": "tests/units/vendorbuy_test.lua",
+    "scan.leak": "tests/units/scan_leak_test.lua",
     "external.buttons": "tests/units/external_buttons_test.lua",
     # definitions.py is deliberately ABSENT. It compares against a git ref and
     # the throwaway copy below has no .git, so every file is skipped as "new"

--- a/tests/units/scan_leak_test.lua
+++ b/tests/units/scan_leak_test.lua
@@ -1,0 +1,209 @@
+-- Aegis: Exchange -- tests/units/scan_leak_test.lua
+--
+-- THE FREEZE. Reported from the field as "multi-second hang a few seconds
+-- after opening the AH, worse the longer the session runs, fine again after a
+-- /reload", and separately as a hang when posting a first auction. One cause:
+--
+--   * scan.OnListUpdate feeds the price DB from EVERY AUCTION_ITEM_LIST_UPDATE
+--     -- deliberately, so manual browsing fills the DB too. That call sat
+--     ABOVE the `phase ~= "wait_results"` gate, so it ran whatever the scanner
+--     was doing.
+--   * It also invoked the running scan's `onListing` callback.
+--   * Finish() set phase = "idle" but never cleared st.callbacks.
+--
+-- So after one Sell-tab price lookup, that lookup's collector stayed armed for
+-- the rest of the session and received every page anyone looked at -- a Buy
+-- search, the stock auction house, a manual browse. It appended matching rows
+-- to sell.listings for ever. A field report showed 910 rows cached for one
+-- item in a category holding 60 auctions.
+--
+-- And it compounded: a cache HIT pointed sell.listings AT the cached array, so
+-- the stray appends then rewrote the cache, and that survived CACHE_TTL -- an
+-- hour. Sorting, copying and grouping that table is what took seconds, on a
+-- path the Sell tab runs whenever it repaints, including after a post.
+--
+-- Nothing about any of this errors. The only symptom is time.
+
+package.path = "tests/support/?.lua;" .. package.path
+local W = require("wow")
+local H = require("harness")
+
+W.Reset()
+local A = W.LoadCore()
+W.FireAddonLoaded(A)
+local sell, scan, db = A.sell, A.scan, A.db
+W.player = "Tester"
+
+W.AddItem(6291, { name = "Raw Brilliant Smallfish", quality = 1 })
+local LINK = W.items[6291].link
+
+local function page(n)
+    local rows = {}
+    for i = 1, n do
+        rows[i] = { name = "Raw Brilliant Smallfish", count = 1,
+                    buyout = 100 * i, minBid = 50, owner = "Other",
+                    level = 1, quality = 1, link = LINK }
+    end
+    return rows
+end
+
+-- A page arriving from somewhere that is NOT our scan: the Buy tab, the stock
+-- auction house, a player clicking Browse.
+local function somebodyElsesPage(rows)
+    W.SetPage(rows, table.getn(rows))
+    W.FireEvent(A.frame, "AUCTION_ITEM_LIST_UPDATE")
+end
+
+-- One Sell-tab price lookup, driven to completion the way the client does.
+local function priceLookup(rows)
+    W.queries = {}
+    W.queryOpen = true
+    sell.ScanItem("Raw Brilliant Smallfish", 6291, nil, nil)
+    W.TickUntil(scan.driver, function() return table.getn(W.queries) > 0 end, 60)
+    W.SetPage(rows, table.getn(rows))
+    W.FireEvent(A.frame, "AUCTION_ITEM_LIST_UPDATE")
+end
+
+-- ---------------------------------------------------------------------------
+H.section("a finished scan stops collecting")
+-- ---------------------------------------------------------------------------
+
+priceLookup(page(10))
+H.eq("the lookup collected its rows", table.getn(sell.listings), 10)
+H.eq("...and cached them", table.getn(sell.cache[6291].listings), 10)
+H.eq("the scanner is idle", scan.state.phase, "idle")
+
+-- THE BUG. Ten unrelated pages, none of them ours.
+local i = 1
+while i <= 10 do somebodyElsesPage(page(10)); i = i + 1 end
+
+H.eq("browsing does NOT append to a finished scan's listings",
+     table.getn(sell.listings), 10)
+H.eq("...and does not rewrite the cache",
+     table.getn(sell.cache[6291].listings), 10)
+
+-- The mechanism, asserted directly rather than only through its effect: a run
+-- that has ended leaves nothing armed.
+H.isNil("a finished run holds no callbacks", scan.state.callbacks)
+
+-- ---------------------------------------------------------------------------
+H.section("...and neither does an abandoned one")
+-- ---------------------------------------------------------------------------
+
+sell.listings = {}
+W.queries = {}
+sell.cache[6291] = nil
+sell.ScanItem("Raw Brilliant Smallfish", 6291, nil, nil)
+W.TickUntil(scan.driver, function() return table.getn(W.queries) > 0 end, 60)
+H.check("a running scan HAS callbacks", scan.state.callbacks ~= nil)
+scan.Stop()
+H.isNil("stopping clears them", scan.state.callbacks)
+
+i = 1
+while i <= 5 do somebodyElsesPage(page(10)); i = i + 1 end
+H.eq("a stopped scan collects nothing", table.getn(sell.listings), 0)
+
+-- ---------------------------------------------------------------------------
+H.section("a LIVE scan only collects the pages it asked for")
+-- ---------------------------------------------------------------------------
+
+-- Clearing the callbacks at the end of a run covers a FINISHED scan. It cannot
+-- cover a live one -- and a live scan spends most of its time not waiting for
+-- results: between pages it sits in "wait_query" behind the throttle, and it
+-- sits in "paused" the whole time a player has walked away from the
+-- auctioneer. Its callbacks are legitimately installed throughout.
+--
+-- So anything that lands a page during those windows -- the player browsing
+-- while a batch bag scan works through the queue, the stock auction house, a
+-- Buy-tab search -- is somebody else's page arriving at an armed collector.
+-- That is what the `ours` argument is for, and nothing else can stand in for
+-- it.
+W.Reset()
+A = W.LoadCore()
+W.FireAddonLoaded(A)
+sell, scan, db = A.sell, A.scan, A.db
+W.player = "Tester"
+W.AddItem(6291, { name = "Raw Brilliant Smallfish", quality = 1 })
+LINK = W.items[6291].link
+
+W.queries = {}
+W.queryOpen = true
+sell.ScanItem("Raw Brilliant Smallfish", 6291, nil, nil)
+W.TickUntil(scan.driver, function() return table.getn(W.queries) > 0 end, 60)
+-- Two pages, so the run has somewhere to go after the first: it lands in
+-- "wait_query" rather than finishing.
+W.SetPage(page(50), 60)
+W.FireEvent(A.frame, "AUCTION_ITEM_LIST_UPDATE")
+H.eq("the page we asked for was collected", table.getn(sell.listings), 50)
+H.eq("the run is between pages", scan.state.phase, "wait_query")
+H.check("...with its callbacks still armed", scan.state.callbacks ~= nil)
+
+somebodyElsesPage(page(10))
+H.eq("a page arriving BETWEEN ours is not collected",
+     table.getn(sell.listings), 50)
+
+scan.Pause()
+H.eq("the run is paused", scan.state.phase, "paused")
+H.check("...still armed", scan.state.callbacks ~= nil)
+somebodyElsesPage(page(10))
+H.eq("a page arriving while PAUSED is not collected",
+     table.getn(sell.listings), 50)
+
+-- ...and the price DB was fed by both of those pages regardless.
+H.check("the browsed pages still reached the price DB",
+        db.MinBuyout(6291) ~= nil)
+
+-- ---------------------------------------------------------------------------
+H.section("the passive price feed still runs on every page")
+-- ---------------------------------------------------------------------------
+
+-- The gate must scope the CALLBACK and nothing else. Feeding the price DB from
+-- any page anyone looks at is the deliberate behaviour that fills the database
+-- while you browse, and a fix that switched it off would be a worse bug than
+-- the freeze -- silent, and only visible as prices that never appear.
+W.AddItem(4306, { name = "Silk Cloth", quality = 1 })
+local SILK = W.items[4306].link
+W.now = W.now + 200000
+H.isNil("the DB has never seen this item", db.MinBuyout(4306))
+
+W.SetPage({ { name = "Silk Cloth", count = 10, buyout = 5000, minBid = 100,
+              owner = "Other", level = 1, quality = 1, link = SILK } }, 1)
+W.FireEvent(A.frame, "AUCTION_ITEM_LIST_UPDATE")
+H.eq("a browsed page still reaches the price DB", db.MinBuyout(4306), 500)
+
+-- ---------------------------------------------------------------------------
+H.section("the cache is never handed out by reference")
+-- ---------------------------------------------------------------------------
+
+-- Even with the gate above, aliasing the cache is its own hazard: anything
+-- that appends to sell.listings would be writing into a table that outlives
+-- the scan by an hour. The read side copies, the write side copies.
+W.Reset()
+A = W.LoadCore()
+W.FireAddonLoaded(A)
+sell, scan = A.sell, A.scan
+W.player = "Tester"
+W.AddItem(6291, { name = "Raw Brilliant Smallfish", quality = 1 })
+LINK = W.items[6291].link
+
+priceLookup(page(4))
+local cached = sell.cache[6291].listings
+H.eq("the scan cached its rows", table.getn(cached), 4)
+H.check("the live table is not the cached one", sell.listings ~= cached)
+
+-- Now take the cache hit, which is the path that used to alias.
+sell.listings = nil
+sell.ScanItem("Raw Brilliant Smallfish", 6291, nil, nil)
+H.eq("a cache hit returns the rows", table.getn(sell.listings), 4)
+H.check("...as a COPY, not the cached table",
+        sell.listings ~= sell.cache[6291].listings)
+
+-- Prove it is a real copy and not a shared row: mutating what the caller holds
+-- must not reach the cache.
+sell.listings[1].unit = 999999
+H.neq("mutating a returned row does not reach the cache",
+      sell.cache[6291].listings[1].unit, 999999)
+table.insert(sell.listings, { count = 1, buyout = 1, unit = 1 })
+H.eq("...and neither does appending", table.getn(sell.cache[6291].listings), 4)
+
+os.exit(H.report("scan.leak"))


### PR DESCRIPTION
Reported as a hang a few seconds after opening the AH, worse the longer a session ran, gone after a /reload -- and separately as a hang when posting a first auction. One cause.

The reporting player traced it far enough to show 910 rows cached for one item in a category holding 60 auctions, and named the accumulation. Their proposed cause -- sell.listings not cleared at scan start -- was wrong; it is cleared, one line above A.scan.Start. The observation was right and the diagnosis was not.

Three links. RecordVisiblePage feeds the price DB from every page anyone looks at, deliberately, so browsing fills it in. It ALSO invoked the running scan's onListing, and it sat above the phase gate -- so it ran whatever the scanner was doing. Finish() then set phase to idle but never cleared st.callbacks. One Sell-tab price lookup therefore left its collector armed for the rest of the session, receiving every page from every source and appending to a table nothing emptied.

The third link made it compound rather than merely grow: ScanItem's cache-hit path aliased the cached array into sell.listings, so the stray appends rewrote the cache, and that survived CACHE_TTL -- an hour. ui/frame.lua already documented this hazard in two places and worked around it by rendering straight from the cache; the alias it was avoiding was never removed.

Sorting, copying and grouping that table is the seconds, on the path the Sell tab runs on every repaint -- including the one after a post.

Three fixes, and the redundancy is deliberate: a scan's collector only receives pages that scan asked for, a run releases its collector on Finish and on Stop, and the cache is copied out as well as in. Two of those independently prevent the reported symptom, which is why one sabotage went unnoticed at first -- with callbacks cleared at Finish, removing the gate no longer leaked on a FINISHED scan. That escape found the case that matters most in the field: a scan is live but NOT waiting for results for most of its life (wait_query between pages, paused while the player walks away), callbacks legitimately armed throughout, and only the gate covers a page landing then.

The passive price feed is untouched, and a sabotage pins that too: gating the whole call rather than the callback would stop the DB filling while you browse -- silent, and a worse bug than the freeze.

Also drops the temporary "Aegis cache store:" chat line.

New scan.leak suite, 25 checks, 7 sabotages. 250/250 caught.


Claude-Session: https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L