### PR TITLE
v1.53.16 -- fix the nil shopDriver at a merchant

### DIFF
--- a/Aegis_Exchange.toc
+++ b/Aegis_Exchange.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: Aegis: Exchange
 ## Notes: Clean auction house helper for Turtle WoW
-## Version: 1.53.15
+## Version: 1.53.16
 ## SavedVariables: AegisExchangeDB
 ## SavedVariablesPerCharacter: AegisExchangeCharDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,28 @@ printed in the window title bar — quote it in bug reports.
 
 ---
 
+## [1.53.16]
+
+### Fixed
+- **A merchant with nothing on your shopping list threw an error on every bag
+  update.** Reported as `frame.lua:16317: attempt to index field 'shopDriver'`,
+  repeating — which is what it does, because the event behind it storms hardest
+  while you are standing at a vendor buying things.
+
+  The shopping list and the cart button on the merchant frame share one
+  once-per-frame flush, and that flush was created as part of the **list**. But
+  the two have different lifetimes: the cart is attached whenever a merchant
+  opens, while the list is only built when something actually shows it — and
+  the automatic popup skips that when you have turned it off or have nothing
+  left to buy. That is the common case, since most characters track no recipes.
+  So an ordinary trip to a vendor left a visible cart button and no flush.
+
+  The flush now stands on its own rather than belonging to the window. It also
+  no longer hangs off the list, which matters beyond the error: a frame whose
+  parent is hidden never runs, so the badge would have stopped counting down
+  in exactly the situation it exists for — list closed, cart on screen, buying.
+
+
 ## [1.53.15]
 
 ### Fixed
@@ -5497,6 +5519,7 @@ that was there before moved behind one **Advanced** button. `/reload`.
 [1.25.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.24.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.23.0]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
+[1.53.16]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.53.15]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.53.14]: https://github.com/Torchlite-bit/Aegis_Exchange/releases
 [1.53.13]: https://github.com/Torchlite-bit/Aegis_Exchange/releases

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aegis: Exchange (v1.53.15)
+# Aegis: Exchange (v1.53.16)
 
 **A clean, fast auction house for vanilla WoW (1.12).**
 
@@ -497,7 +497,7 @@ which were learned the hard way.
 
 ## Something broken?
 
-1. Check the **version** in the window's title bar (`v1.53.15`) — quote it.
+1. Check the **version** in the window's title bar (`v1.53.16`) — quote it.
 2. **`/aex diag <shift-click an item>`** prints everything Aegis knows about
    that item and every step it took: which modules loaded, what the client
    returned, the item level and where it came from, and the disenchant value.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2390,6 +2390,44 @@ Worth noting what the mock hid again: `UnitFactionGroup` ignored its argument
 and always answered "Alliance", so a neutral auctioneer could not be modelled
 at all -- and the addon ignored that case for exactly as long.
 
+### A flush that belonged to the wrong thing — v1.53.16
+
+**`attempt to index field 'shopDriver' (a nil value)`, once per BAG_UPDATE, at
+a merchant.** Reported from a live client.
+
+**The nil was the symptom; the ownership was the bug.** One once-per-frame
+flush drives two surfaces -- the shopping list and the cart button on the
+merchant frame -- and it was created inside `ui.BuildShopWindow`. Those two
+have DIFFERENT LIFETIMES: the cart is attached from the merchant handler
+whenever a vendor opens, while the window is built only when something actually
+shows it, and the auto-popup returns early twice before it gets there (setting
+off, nothing left to buy). The second of those is the common case, because most
+characters track no recipes at all. So the ordinary path -- walk up to any
+vendor -- produced a visible cart and no driver, and then BAG_UPDATE storms.
+
+**A nil guard would have "fixed" it and left half of it broken silently.** A
+frame whose PARENT is hidden does not run its OnUpdate. The driver hung off the
+list, so even with the crash guarded, the badge would have stopped refreshing
+in exactly the case it exists for: list closed, cart on screen, player buying.
+Reparenting to UIParent is not tidying -- it is the other half of the fix.
+**When the error is "this field is nil", ask what owns the field before
+reaching for `if x then`.**
+
+**The test RUNS the handler; it does not read it.** The suite already had three
+source checks over this exact handler and all three passed while it crashed on
+a real client, because "does the handler mention the driver" was always true.
+The regression check loads the handler, puts the addon in the reported state --
+cart visible, list never built -- and calls it. Four sabotages: the ownership
+restored, the parent moved back onto the list, the memo dropped, and the cart
+taken off the arming condition.
+
+**And two source checks were anchored on text that moved.** One keyed on the
+handler's first body line, which changed when the two visibility tests were
+folded into one condition; it now anchors on the handler's own comment, which
+is the only thing unique to it among the file's four BAG_UPDATE registrations.
+A length guard that failed at 721 characters against a 600 cap was raised --
+after checking it was the comment that grew, not the extraction that ran away.
+
 ### The addon already knew this, and I did not ask it — v1.53.15
 
 **A red box where every shopping-list icon should have been.** Two mistakes

--- a/core/init.lua
+++ b/core/init.lua
@@ -22,7 +22,7 @@ A.name    = "Aegis_Exchange"   -- must match the folder / .toc / ADDON_LOADED
 -- Shown in the window title bar and printed at load. Bump on EVERY push the
 -- user will test — it is the only reliable way to know which build produced
 -- an in-game bug report.
-A.version = "1.53.15"
+A.version = "1.53.16"
 
 -- Detect Turtle WoW. Turtle exposes a global TURTLE_WOW_VERSION.
 A.isTurtle = (TURTLE_WOW_VERSION ~= nil)

--- a/tests/sabotage.py
+++ b/tests/sabotage.py
@@ -2700,15 +2700,15 @@ end
     # merchant window is open and the player is buying -- the shape HARD RULE
     # 16 exists for.
     ('cart-counts-inside-bag-update', 'ui/frame.lua',
-     '    if ui.shopCartBtn and ui.shopCartBtn:IsVisible() then\n        ui.shopDriver:Show()\n    end',
-     '    if ui.shopCartBtn and ui.shopCartBtn:IsVisible() then\n        ui.RefreshShopCartButton()\n    end',
+     '        ui.ShopDriver():Show()',
+     '        ui.RefreshShopCartButton()',
      'shoplist'),
 
     # ...and the other way: the flush stops refreshing it, so the badge keeps
     # whatever count it had when the merchant opened.
     ('cart-badge-never-flushed', 'ui/frame.lua',
-     '        ui.RefreshShopCartButton()\n    end)',
-     '    end)',
+     '        ui.RefreshShopCartButton()\n    end)\n    ui.shopDriver = d',
+     '    end)\n    ui.shopDriver = d',
      'shoplist'),
 
     # The cart left reading as pressed after the list is closed by its own X
@@ -2942,15 +2942,65 @@ end
     # doubly so here, because a merchant window is open and the player is
     # buying, which is exactly when that event storms.
     ('shop-rebuilds-inside-bag-update', 'ui/frame.lua',
-     '    if ui.shopFrame and ui.shopFrame:IsVisible() then ui.shopDriver:Show() end',
-     '    if ui.shopFrame and ui.shopFrame:IsVisible() then ui.RefreshShopWindow() end',
+     '        ui.ShopDriver():Show()\n    end\nend)',
+     '        ui.RefreshShopWindow()\n    end\nend)',
      'shoplist'),
 
     # The flush driver left running, so the list is rebuilt every frame for
     # the rest of the session.
     ('shop-driver-never-stops', 'ui/frame.lua',
-     '    ui.shopDriver:SetScript("OnUpdate", function()\n        ui.shopDriver:Hide()',
-     '    ui.shopDriver:SetScript("OnUpdate", function()',
+     '    d:SetScript("OnUpdate", function()\n        d:Hide()',
+     '    d:SetScript("OnUpdate", function()',
+     'shoplist'),
+
+    # ---- the nil driver (v1.53.16) --------------------------------------
+
+    # THE BUG AS REPORTED, put straight back: the driver owned by the window
+    # rather than by itself. The cart button is attached whenever a merchant
+    # opens; the window is built only when something shows it, which the
+    # auto-popup skips when the setting is off or there is nothing left to buy.
+    # So a merchant plus an empty shopping list -- the common case -- left a
+    # visible cart and a nil driver, and every BAG_UPDATE threw.
+    ('shop-driver-owned-by-the-window', 'ui/frame.lua',
+     '''function ui.ShopDriver()
+    if ui.shopDriver then return ui.shopDriver end
+    local d = CreateFrame("Frame", nil, UIParent)''',
+     '''function ui.ShopDriver()
+    if not ui.shopFrame then return ui.shopDriver end
+    if ui.shopDriver then return ui.shopDriver end
+    local d = CreateFrame("Frame", nil, UIParent)''',
+     'shoplist'),
+
+    # ...and the half a nil-guard alone would have left broken and silent: a
+    # frame whose PARENT is hidden does not run its OnUpdate, so a driver
+    # hanging off the list goes quiet in exactly the case the cart badge exists
+    # for -- list closed, cart on screen, player buying.
+    ('shop-driver-parented-to-the-list', 'ui/frame.lua',
+     '    local d = CreateFrame("Frame", nil, UIParent)',
+     '    local d = CreateFrame("Frame", nil, ui.shopFrame)',
+     'shoplist'),
+
+    # The memo dropped, so every bag update creates another frame with another
+    # OnUpdate -- a leak that compounds at the moment BAG_UPDATE storms.
+    ('shop-driver-not-memoised', 'ui/frame.lua',
+     '    if ui.shopDriver then return ui.shopDriver end',
+     '    if false then return ui.shopDriver end',
+     'shoplist'),
+
+    # Only the list arms the flush, so the cart badge stops counting down as
+    # you buy -- which is the entire point of the badge.
+    ('cart-does-not-arm-the-flush', 'ui/frame.lua',
+     '''    if (ui.shopFrame and ui.shopFrame:IsVisible())
+        or (ui.shopCartBtn and ui.shopCartBtn:IsVisible()) then''',
+     '''    if (ui.shopFrame and ui.shopFrame:IsVisible()) then''',
+     'shoplist'),
+
+    # ...and the flush armed unconditionally, which is a repaint every bag
+    # update for the whole session whether anything is on screen or not.
+    ('flush-armed-with-nothing-on-screen', 'ui/frame.lua',
+     '''    if (ui.shopFrame and ui.shopFrame:IsVisible())
+        or (ui.shopCartBtn and ui.shopCartBtn:IsVisible()) then''',
+     '''    if true then''',
      'shoplist'),
 
     # An empty frame popped over the merchant window every time you talk to a

--- a/tests/units/shoplist_test.lua
+++ b/tests/units/shoplist_test.lua
@@ -216,14 +216,16 @@ do
     -- and doubly so here, because a merchant window is open and the player is
     -- buying.
     H.check("the bag handler only sets a flag",
-            says(src, "if ui.shopFrame and ui.shopFrame:IsVisible() then ui.shopDriver:Show() end"),
+            says(src, "ui.ShopDriver():Show()")
+            and not says(src, "ui.RefreshShopWindow()\nend)"),
             "a rebuild inside BAG_UPDATE is what froze Courier")
-    -- NESTED inside ui.BuildShopWindow, so its terminator carries the
-    -- indentation it closes at.
-    local driver = bodyTo("ui.shopDriver:SetScript(\"OnUpdate\"", "\n    end)")
+    -- NESTED inside ui.ShopDriver, so its terminator carries the indentation
+    -- it closes at. It used to live inside ui.BuildShopWindow, and moving it
+    -- out is the fix for the nil-driver crash -- see the last section.
+    local driver = bodyTo('d:SetScript("OnUpdate"', "\n    end)")
     H.check("the driver was found", driver ~= "" and string.len(driver) < 600,
             string.len(driver))
-    H.check("...and it stops itself", says(driver, "ui.shopDriver:Hide()"))
+    H.check("...and it stops itself", says(driver, "d:Hide()"))
 
     -- NOTHING TO BUY, NOTHING TO SHOW. Popping an empty frame over the
     -- merchant window every time you talk to a vendor is the behaviour that
@@ -311,15 +313,24 @@ do
     -- FILE -- and every check against it then passed on text from somewhere
     -- else entirely. The one below failed loudly, which is the only reason
     -- the other three were not quietly meaningless.
-    local bag = bodyTo('A.RegisterEvent("BAG_UPDATE", function()\n    if ui.shopFrame',
+    -- ANCHORED ON ITS OWN COMMENT. Four handlers in this file register
+    -- BAG_UPDATE, so the head has to be the one thing unique to this one --
+    -- keying on the first line of the body meant the extraction broke the
+    -- moment that line was reworded, which is exactly what happened when the
+    -- two surfaces were folded into one condition.
+    local bag = bodyTo("-- O(1): a flag and a Show. See ui.ShopDriver.",
                        "\nend)\n")
-    H.check("the bag handler was found", bag ~= "" and string.len(bag) < 600,
+    -- The cap is a runaway guard, not a style budget -- it exists so a failed
+    -- extraction that swallowed the rest of the file fails loudly instead of
+    -- matching everything asked of it. Raised from 600 when the handler's
+    -- comment grew; the body itself is still twenty lines.
+    H.check("the bag handler was found", bag ~= "" and string.len(bag) < 1000,
             string.len(bag))
     H.check("the bag handler only sets a flag for the cart",
-            says(bag, "ui.shopDriver:Show()")
+            says(bag, "ui.ShopDriver():Show()")
             and not says(bag, "ui.RefreshShopCartButton()"),
             "counting the list inside BAG_UPDATE is the shape that froze Courier")
-    local driver = bodyTo('ui.shopDriver:SetScript("OnUpdate"', "\n    end)")
+    local driver = bodyTo('d:SetScript("OnUpdate"', "\n    end)")
     H.check("...and the flush does the counting",
             says(driver, "ui.RefreshShopCartButton()"))
 
@@ -331,6 +342,133 @@ do
     H.check("...and showing it does too",
             says(bodyOf("function ui.ShowShopWindow("),
                  "ui.RefreshShopCartButton()"))
+end
+
+-- ---------------------------------------------------------------------------
+H.section("the flush outlives the window that used to own it")
+-- ---------------------------------------------------------------------------
+
+-- THE REPORTED CRASH, reproduced rather than described:
+--
+--   frame.lua:16317: attempt to index field `shopDriver' (a nil value)
+--
+-- The driver was created inside ui.BuildShopWindow, but it drives TWO surfaces
+-- with separate lifetimes -- the list, built only when something actually
+-- shows it, and the cart button, attached whenever a merchant opens. The
+-- auto-popup skips building the list when the setting is off or there is
+-- nothing left to buy, which is the COMMON case because most characters track
+-- no recipes. So any merchant left a visible cart and no driver, and every
+-- BAG_UPDATE threw -- at the moment BAG_UPDATE fires hardest.
+--
+-- RUN, NOT READ. A source check would have said the handler mentions the
+-- driver, which it always did. Only executing it in that state says whether
+-- the field is there.
+do
+    local f = assert(io.open(SRC, "r"), "run this from the repo root")
+    local src = f:read("*a")
+    f:close()
+
+    local fn, err = loadstring(extract("function ui.ShopDriver("), "ShopDriver")
+    if not fn then error("ui.ShopDriver will not compile: " .. tostring(err)) end
+    fn()
+
+    -- FOUR handlers in this file register BAG_UPDATE, so the head has to be
+    -- the one thing unique to this one -- its own comment. Anchoring on
+    -- `A.RegisterEvent("BAG_UPDATE"` picks up whichever comes first.
+    local HEAD = "-- O(1): a flag and a Show. See ui.ShopDriver."
+    local at = string.find(src, HEAD, 1, true)
+    H.check("the shop's bag handler was found", at ~= nil, "head moved")
+    local stop = string.find(src, "\nend)", at or 1, true)
+    local body = string.sub(src, at or 1, stop and (stop + 5) or -1)
+    -- A body that ran away is a body far too long. Same guard the extractions
+    -- above carry, for the same reason.
+    H.check("...and the extraction stopped where it should",
+            string.len(body) < 1200, string.len(body))
+
+    -- THE GLOBAL, not this file's local. `local A = W.LoadCore()` at the top
+    -- shadows it here, and the loaded chunk resolves `A` as a global -- so
+    -- assigning the bare name would set the local and leave the chunk reading
+    -- nil. Saved and put back, because the addon's real namespace is a global
+    -- too and everything after this expects it.
+    local realA = _G.A
+    local captured
+    _G.A = { RegisterEvent = function(evt, handler)
+        if evt == "BAG_UPDATE" then captured = handler end
+    end }
+    local loaded, lerr = loadstring(body, "bagupdate")
+    if not loaded then error("the handler will not compile: " .. tostring(lerr)) end
+    loaded()
+    H.check("the handler registered", captured ~= nil)
+
+    local painted, badged = 0, 0
+    ui.RefreshShopWindow = function() painted = painted + 1 end
+    ui.RefreshShopCartButton = function() badged = badged + 1 end
+
+    local function visible() return true end
+
+    -- ---- the exact reported state: a cart, no list ----------------------
+    ui.shopDriver, ui.shopFrame = nil, nil
+    ui.shopCartBtn = { IsVisible = visible }
+    H.survives("a bag update with a cart and no list is not an error", captured)
+    H.check("...and it armed the flush",
+            ui.shopDriver and ui.shopDriver:IsVisible(),
+            "the badge would never follow what you buy")
+
+    -- The flush itself, in that same state.
+    painted, badged = 0, 0
+    ui.shopDriver:GetScript("OnUpdate")()
+    H.eq("the flush repaints the badge", badged, 1)
+    H.eq("...and does not repaint a list that is not up", painted, 0)
+    H.check("...and disarms itself", not ui.shopDriver:IsVisible(),
+            "a flush that stays armed is an every-frame rescan")
+
+    -- ---- ITS PARENT IS UIParent, and that is not cosmetic ---------------
+    --
+    -- A frame whose PARENT is hidden does not run its OnUpdate. A driver
+    -- hanging off the list would therefore have gone quiet in exactly the case
+    -- the cart badge exists for -- list closed, cart on screen, player buying
+    -- -- so fixing only the nil would have left that half broken and silent.
+    H.check("the flush does not hang off the list",
+            ui.shopDriver:GetParent() == UIParent,
+            "a driver parented to a hidden list never runs")
+
+    -- ---- MEMOISED. One frame, not one per bag update. -------------------
+    local first = ui.ShopDriver()
+    H.check("asking again returns the same frame", ui.ShopDriver() == first)
+    captured(); captured(); captured()
+    H.check("...and a storm of bag updates creates no more",
+            ui.ShopDriver() == first,
+            "a frame per fire is a leak at the moment BAG_UPDATE storms")
+
+    -- ---- a list and no cart, which is /aex shop away from a merchant ----
+    ui.shopDriver, ui.shopCartBtn = nil, nil
+    ui.shopFrame = { IsVisible = visible }
+    H.survives("a bag update with a list and no cart is not an error", captured)
+    H.check("...and it armed the flush", ui.shopDriver:IsVisible())
+    painted, badged = 0, 0
+    ui.shopDriver:GetScript("OnUpdate")()
+    H.eq("the flush repaints the list", painted, 1)
+    -- The badge refresh still RUNS -- it returns early by itself when there is
+    -- no button. The flush may not have to know which surfaces exist.
+    H.eq("...and asks the badge, which answers for itself", badged, 1)
+
+    -- ---- NEITHER on screen: nothing is armed ---------------------------
+    ui.shopFrame, ui.shopCartBtn = nil, nil
+    ui.shopDriver:Hide()
+    H.survives("a bag update with nothing on screen is not an error", captured)
+    H.check("...and arms nothing", not ui.shopDriver:IsVisible(),
+            "flushing with nothing on screen is work for no reason")
+
+    -- ...including when both exist but are hidden, which is the state after
+    -- you walk away from a merchant with the list closed.
+    local hidden = function() return false end
+    ui.shopFrame = { IsVisible = hidden }
+    ui.shopCartBtn = { IsVisible = hidden }
+    captured()
+    H.check("a hidden cart and a hidden list arm nothing",
+            not ui.shopDriver:IsVisible())
+
+    _G.A = realA
 end
 
 os.exit(H.report("shoplist"))

--- a/ui/frame.lua
+++ b/ui/frame.lua
@@ -16051,6 +16051,45 @@ local SHOPL = {
     pad = 8,
 }
 
+-- The once-per-frame flush for everything the shopping list drives.
+--
+-- BAG_UPDATE STORMS, so its handler is a flag and a Show and nothing else. The
+-- rebuild is a walk of every tracked recipe's reagents, which is exactly the
+-- shape HARD RULE 16 forbids inside a handler -- and it is doubly so here,
+-- because a merchant window is open and the player is buying.
+--
+-- IT IS NOT OWNED BY THE WINDOW, and that was the bug. It used to be created
+-- inside ui.BuildShopWindow, but it drives TWO surfaces with SEPARATE
+-- lifetimes: the list, built only when something actually shows it, and the
+-- cart button, attached whenever a merchant opens. The auto-popup skips
+-- building the list when the setting is off or there is nothing left to buy --
+-- which is the common case, since most characters track no recipes -- so any
+-- merchant left a visible cart button and no driver, and every BAG_UPDATE
+-- threw. One error per fire, at the moment BAG_UPDATE fires hardest.
+--
+-- PARENTED TO UIParent, NOT TO THE LIST. A frame whose parent is hidden does
+-- not run its OnUpdate, so a driver hanging off the list would have gone quiet
+-- in precisely the case the cart badge exists for: list closed, cart on screen,
+-- player buying. Fixing only the nil would have left that half broken and
+-- silent.
+function ui.ShopDriver()
+    if ui.shopDriver then return ui.shopDriver end
+    local d = CreateFrame("Frame", nil, UIParent)
+    d:Hide()
+    d:SetScript("OnUpdate", function()
+        d:Hide()
+        -- Each surface checks for itself. Neither refresh assumes the other's
+        -- widgets exist: RefreshShopCartButton returns early without a button,
+        -- and the list is only repainted while it is actually up.
+        if ui.shopFrame and ui.shopFrame:IsVisible() then
+            ui.RefreshShopWindow()
+        end
+        ui.RefreshShopCartButton()
+    end)
+    ui.shopDriver = d
+    return d
+end
+
 function ui.BuildShopWindow()
     if ui.shopFrame then return ui.shopFrame end
     local f = CreateFrame("Frame", "AegisExchangeShopList", UIParent)
@@ -16145,22 +16184,9 @@ function ui.BuildShopWindow()
         i = i + 1
     end
 
-    -- BAG_UPDATE STORMS, so this is a flag and a Show and nothing else. The
-    -- rebuild is a walk of every tracked recipe's reagents, which is exactly
-    -- the shape HARD RULE 16 forbids inside a handler -- and it is doubly so
-    -- here, because a merchant window is open and the player is buying.
-    ui.shopDriver = CreateFrame("Frame", nil, f)
-    ui.shopDriver:Hide()
-    ui.shopDriver:SetScript("OnUpdate", function()
-        ui.shopDriver:Hide()
-        if ui.shopFrame and ui.shopFrame:IsVisible() then
-            ui.RefreshShopWindow()
-        end
-        -- The badge follows the same flush. It is behind the same dirty flag
-        -- for the same reason: counting the list is a walk, and BAG_UPDATE
-        -- storms hardest while a merchant is open.
-        ui.RefreshShopCartButton()
-    end)
+    -- The flush is SHARED and outlives this window -- see ui.ShopDriver. Asked
+    -- for here so a list built before any merchant was opened still has one.
+    ui.ShopDriver()
     return f
 end
 
@@ -16308,13 +16334,19 @@ A.RegisterEvent("MERCHANT_CLOSED", function()
     end
 end)
 
--- O(1): a flag and a Show. See ui.shopDriver.
+-- O(1): a flag and a Show. See ui.ShopDriver.
+--
+-- EITHER SURFACE IS ENOUGH, and they are checked together rather than in two
+-- statements, because the two have separate lifetimes and either one alone is
+-- a reason to flush: the list so it repaints, the cart so its badge follows
+-- what you buy.
 A.RegisterEvent("BAG_UPDATE", function()
-    if ui.shopFrame and ui.shopFrame:IsVisible() then ui.shopDriver:Show() end
-    -- ...and while the cart is on screen, so its badge follows what you buy.
-    -- Still only a flag and a Show.
-    if ui.shopCartBtn and ui.shopCartBtn:IsVisible() then
-        ui.shopDriver:Show()
+    if (ui.shopFrame and ui.shopFrame:IsVisible())
+        or (ui.shopCartBtn and ui.shopCartBtn:IsVisible()) then
+        -- ui.ShopDriver() is O(1) after the first call and creates one frame
+        -- on it, which is why asking here rather than indexing a field that
+        -- may not have been filled yet is still within HARD RULE 16.
+        ui.ShopDriver():Show()
     end
 end)
 


### PR DESCRIPTION
frame.lua:16317: attempt to index field 'shopDriver' (a nil value), repeating. Reported from a live client.

THE NIL WAS THE SYMPTOM; THE OWNERSHIP WAS THE BUG. One once-per-frame flush drives two surfaces -- the shopping list and the cart button on the merchant frame -- and it was created inside ui.BuildShopWindow. Those two have different lifetimes: the cart is attached whenever a vendor opens, while the window is built only when something actually shows it, and the auto-popup returns early twice before reaching that (setting off, nothing left to buy). The second is the common case, since most characters track no recipes. So walking up to any vendor left a visible cart and no driver -- and BAG_UPDATE storms there.

The flush now stands on its own via ui.ShopDriver(), lazily created and memoised, rather than belonging to the window.

A NIL GUARD ALONE WOULD HAVE LEFT HALF OF IT BROKEN AND SILENT. A frame whose parent is hidden does not run its OnUpdate, and the driver hung off the list -- so even with the crash guarded, the badge would have stopped refreshing in exactly the case it exists for: list closed, cart on screen, player buying. Reparenting to UIParent is the other half of the fix, not tidying.

The regression check RUNS the handler rather than reading it. Three source checks already covered this handler and all three passed while it crashed on a real client, because "does the handler mention the driver" was always true. The new one loads it, puts the addon in the reported state -- cart visible, list never built -- and calls it.

Six sabotages: the ownership restored, the parent moved back onto the list, the memo dropped, the cart taken off the arming condition, the flush armed unconditionally, and the badge count moved back inside the handler. All caught.

Also re-anchored two source checks that keyed on text which moved, and raised a runaway guard that failed at 721 against a 600 cap -- after confirming it was the comment that grew, not the extraction that ran away.

612 sabotages, all caught.


Claude-Session: https://claude.ai/code/session_01BWxeqhB2H24jojteUWUV1L